### PR TITLE
Support GitHub release files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
           R CMD check --no-build-vignettes --no-manual --no-tests pins*tar.gz
           Rscript ci/travis.R
       env:
-        -TEST_GITHUB_BRANCH="travis_old"
+        -TEST_GITHUB_BRANCH="travis"
       after_success:
         - rm -rf ~/.pins
         - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.1.1
+Version: 0.1.1.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# pins 0.1.1.9000 (unreleased)
+
+- Support to upload files larger than 50mb in GitHub boards
+  as release files.
+
 # pins 0.1.1
 
 - Fix CRAN request to explicitly opt-in to use local home

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -132,7 +132,7 @@ github_create_release <- function(board, name) {
     body = release,
     github_headers(board), encode = "json")
 
-  if (httr::http_error(response)) stop("Failed to create release for '", name, "': ", httr::content(response)$message)
+  if (httr::http_error(response)) stop("Failed to create release '", tag_name, "' for '", name, "': ", httr::content(response)$message)
 
   httr::content(response)
 }

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -113,7 +113,7 @@ github_update_index <- function(board, path, commit, operation, name = NULL, met
 }
 
 github_create_release <- function(board, name) {
-  index_url <- github_url(board, branch = board$branch, "/contents/", board$path, "data.txt")
+  index_url <- github_url(board, branch = NULL, "/commits/", board$branch)
   response <- httr::GET(index_url, github_headers(board))
   version <- "initial"
   if (!httr::http_error(response)) version <- substr(httr::content(response)$sha, 1, 7)

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -409,9 +409,9 @@ board_pin_get.github <- function(board, name, ...) {
 
     for (file in index$path) {
       file_url <- file
+      headers <- github_headers(board)
 
       if (grepl("^http://|^https://", file)) {
-        headers <- github_headers(board)
         # retrieving releases fails if auth headers are specified
         headers <- NULL
       }

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -132,7 +132,7 @@ github_create_release <- function(board, name) {
     body = release,
     github_headers(board), encode = "json")
 
-  if (httr::http_error(response)) stop("Failed to create release '", tag_name, "' for '", name, "': ", httr::content(response)$message)
+  if (httr::http_error(response)) stop("Failed to create release '", release$tag_name, "' for '", name, "': ", httr::content(response)$message)
 
   httr::content(response)
 }

--- a/R/pin.R
+++ b/R/pin.R
@@ -198,14 +198,17 @@ pin_remove <- function(name, board) {
 #' # search pins related to 'seattle' in the 'packages' board
 #' pin_find("seattle", board = "packages")
 #'
-#' # retrieve 'hpiR/seattle_sales' pin
-#' pin_get("hpiR/seattle_sales")
-#'
 #' # search pins related to 'london' in the 'packages' board
 #' pin_find("london", board = "packages")
 #'
+#' \donttest{
+#' # retrieve 'hpiR/seattle_sales' pin
+#' pin_get("hpiR/seattle_sales")
+#'
 #' # retrieve 'bsamGP/London.Mortality' pin
 #' pin_get("bsamGP/London.Mortality")
+#' }
+#'
 #' @export
 pin_find <- function(text = NULL, board = NULL, ...) {
   if (is.null(board) || nchar(board) == 0) board <- board_list()

--- a/man/pin_find.Rd
+++ b/man/pin_find.Rd
@@ -44,12 +44,15 @@ pin_find("cars")
 # search pins related to 'seattle' in the 'packages' board
 pin_find("seattle", board = "packages")
 
-# retrieve 'hpiR/seattle_sales' pin
-pin_get("hpiR/seattle_sales")
-
 # search pins related to 'london' in the 'packages' board
 pin_find("london", board = "packages")
 
+\donttest{
+# retrieve 'hpiR/seattle_sales' pin
+pin_get("hpiR/seattle_sales")
+
 # retrieve 'bsamGP/London.Mortality' pin
 pin_get("bsamGP/London.Mortality")
+}
+
 }

--- a/tests/testthat/test-board-github.R
+++ b/tests/testthat/test-board-github.R
@@ -17,3 +17,15 @@ if (test_board_is_registered("github")) {
     skip("failed to register github board")
   })
 }
+
+test_that("can pin large resources in github releases", {
+  pin(iris, "iris_large", board = "github", release_storage = TRUE)
+
+  retrieved <- pin_get("iris_large", board = "github")
+
+  expect_true(is.data.frame(retrieved))
+
+  pin_remove("iris_large", board = "github")
+
+  expect_true(!"iris_large" %in% pin_find(board = "github")$name)
+})


### PR DESCRIPTION
GitHub only allows 100MB files to be uploaded as content, the API takes a `base64` encoded file which makes it even lower than  100MB. This PR adds support to store files larger than 50MB (due to encoding overhead) to be store as GitHub release files. See [Distributing large binaries](https://help.github.com/en/articles/distributing-large-binaries).