### PR TITLE
Follow up fix for GitHub Releases feature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins 0.1.2.9000 (unreleased)
 
+- Fix for data.txt boards created from GitHub boards using
+  large files.
+
 - Fix for data frames with nested data frames in rsconnect
   boards (#36).
 


### PR DESCRIPTION
The GitHub board might create GitHub releases to store large files (as recommended by GitHub); however, boards that only register the `data.txt` YAML file currently can't download those large GitHub files, and in general, any URL reference stored in the pin manifest.