### PR TITLE
Properly store file ext in metadata

### DIFF
--- a/R/pin_file.R
+++ b/R/pin_file.R
@@ -16,5 +16,6 @@ pin_file_cache_max_age <- function(cache_control) {
 #' @keywords internal
 #' @export
 pin.character <- function(x, name = NULL, description = NULL, board = NULL, ...) {
-  board_pin_store(board, x, name, description, "files", list(), ...)
+  extension <- if (length(x) > 1) "zip" else tools::file_ext(x)
+  board_pin_store(board, x, name, description, "files", list(extension = extension), ...)
 }


### PR DESCRIPTION
When searching for resources in the UI viewer, the extension might be missing in file-based pins.