### PR TITLE
Register local board by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,15 @@
 # pins 0.1.2.9000 (unreleased)
 
+- Add support for `RSCONNECT_SERVER` environment variable to
+  ease configuration of automated RStudio Connect reports.
+
+- Using a board will attempt to automatically register, such
+  that `pin(iris, board = "rsconnect")` would work for
+  the default configuration even when the board is not
+  explicitly registered (#50).
+
 - Registers "local" board by default, you no longer need to 
-  explicitly run `board_register_local()`.
+  explicitly run `board_register_local()` (#56).
 
 - Fix intermittent failure to retrieve pins from RStudio
   Connect boards while creating them.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins 0.1.2.9000 (unreleased)
 
+- Registers "local" board by default, you no longer need to 
+  explicitly run `board_register_local()`.
+
 - Fix intermittent failure to retrieve pins from RStudio
   Connect boards while creating them.
 

--- a/R/board.R
+++ b/R/board.R
@@ -188,10 +188,15 @@ board_deregister <- function(name, ...) {
 
 #' Default Board
 #'
-#' Retrieves the default board, which defaults to \code{"temp"} but can also be
+#' Retrieves the default board, which defaults to \code{"local"} but can also be
 #' configured with the \code{pins.board} option.
 #'
 #' @examples
+#'
+#' library(pins)
+#'
+#' # create temp board
+#' board_register_local("temp")
 #'
 #' # configure default board
 #' options(pind.board = "temp")
@@ -201,5 +206,5 @@ board_deregister <- function(name, ...) {
 #'
 #' @export
 board_default <- function() {
-  getOption("pins.board", "temp")
+  getOption("pins.board", "local")
 }

--- a/R/board.R
+++ b/R/board.R
@@ -196,10 +196,7 @@ board_deregister <- function(name, ...) {
 #' library(pins)
 #'
 #' # create temp board
-#' board_register_local("temp")
-#'
-#' # configure default board
-#' options(pind.board = "temp")
+#' board_register_local("temp", cache = tempfile())
 #'
 #' # retrieve default board
 #' board_default()

--- a/R/board.R
+++ b/R/board.R
@@ -1,6 +1,6 @@
 new_board <- function(board, name, cache, ...) {
 
-  if (is.null(cache)) stop("Please specify the 'cache' parameter, usually set to '~/.pins'.")
+  if (is.null(cache)) stop("Please specify the 'cache' parameter.")
 
   board <- structure(list(
       board = board,
@@ -197,6 +197,9 @@ board_deregister <- function(name, ...) {
 #'
 #' # create temp board
 #' board_register_local("temp", cache = tempfile())
+#'
+#' # configure default board
+#' options(pind.board = "temp")
 #'
 #' # retrieve default board
 #' board_default()

--- a/R/board_packages.R
+++ b/R/board_packages.R
@@ -1,4 +1,7 @@
 board_initialize.packages <- function(board, ...) {
+  # use local board cache to avoid 'board_register("packages", cache = tempfile())' examples
+  if (identical(board$cache, board_cache_path())) board$cache <- pins:::board_local_storage("local")
+
   board
 }
 

--- a/R/board_packages.R
+++ b/R/board_packages.R
@@ -1,6 +1,6 @@
 board_initialize.packages <- function(board, ...) {
   # use local board cache to avoid 'board_register("packages", cache = tempfile())' examples
-  if (identical(board$cache, board_cache_path())) board$cache <- board_local_storage("local")
+  if (identical(board$cache, board_cache_path())) board$cache <- dirname(board_local_storage("local"))
 
   board
 }

--- a/R/board_packages.R
+++ b/R/board_packages.R
@@ -1,6 +1,6 @@
 board_initialize.packages <- function(board, ...) {
   # use local board cache to avoid 'board_register("packages", cache = tempfile())' examples
-  if (identical(board$cache, board_cache_path())) board$cache <- pins:::board_local_storage("local")
+  if (identical(board$cache, board_cache_path())) board$cache <- board_local_storage("local")
 
   board
 }

--- a/R/board_registry.R
+++ b/R/board_registry.R
@@ -6,8 +6,8 @@ board_registry_ensure <- function() {
 }
 
 board_registry_defaults <- function() {
-  if (!"temp" %in% names(.globals$boards_registered)) board_register("local", name = "temp", cache = tempfile(), connect = FALSE)
-  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = tempfile(), connect = FALSE)
+  if (!"local" %in% names(.globals$boards_registered)) board_register("local", name = "local", connect = FALSE)
+  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local")), connect = FALSE)
   if (!board_default() %in% names(.globals$boards_registered)) board_register(board_default(), connect = FALSE)
 }
 

--- a/R/board_registry.R
+++ b/R/board_registry.R
@@ -7,7 +7,7 @@ board_registry_ensure <- function() {
 
 board_registry_defaults <- function() {
   if (!"local" %in% names(.globals$boards_registered)) board_register("local", name = "local", connect = FALSE)
-  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local")), connect = FALSE)
+  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local", board = board_get("local"))), connect = FALSE)
   if (!board_default() %in% names(.globals$boards_registered)) board_register(board_default(), connect = FALSE)
 }
 

--- a/R/board_registry.R
+++ b/R/board_registry.R
@@ -1,13 +1,13 @@
-board_registry_ensure <- function() {
+board_registry_ensure <- function(register = TRUE) {
   if (identical(.globals$boards_registered, NULL)) {
     .globals$boards_registered <- list()
-    board_registry_defaults()
+    if (register) board_registry_defaults()
   }
 }
 
 board_registry_defaults <- function() {
   if (!"local" %in% names(.globals$boards_registered)) board_register("local", name = "local", connect = FALSE)
-  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local", board = board_get("local"))), connect = FALSE)
+  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local")), connect = FALSE)
   if (!board_default() %in% names(.globals$boards_registered)) board_register(board_default(), connect = FALSE)
 }
 
@@ -24,7 +24,9 @@ board_registry_get <- function(name) {
 }
 
 board_registry_set <- function(name, board) {
-  board_registry_ensure()
+  board_registry_ensure(FALSE)
 
   .globals$boards_registered[[name]] <- board
+
+  board_registry_defaults()
 }

--- a/R/board_registry.R
+++ b/R/board_registry.R
@@ -1,14 +1,7 @@
 board_registry_ensure <- function(register = TRUE) {
   if (identical(.globals$boards_registered, NULL)) {
     .globals$boards_registered <- list()
-    if (register) board_registry_defaults()
   }
-}
-
-board_registry_defaults <- function() {
-  if (!"local" %in% names(.globals$boards_registered)) board_register("local", name = "local", connect = FALSE)
-  if (!"packages" %in% names(.globals$boards_registered)) board_register("packages", cache = dirname(board_local_storage("local")), connect = FALSE)
-  if (!board_default() %in% names(.globals$boards_registered)) board_register(board_default(), connect = FALSE)
 }
 
 board_registry_list <- function() {
@@ -27,6 +20,4 @@ board_registry_set <- function(name, board) {
   board_registry_ensure(FALSE)
 
   .globals$boards_registered[[name]] <- board
-
-  board_registry_defaults()
 }

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -16,6 +16,11 @@ board_initialize.rsconnect <- function(board, ...) {
     args$key <- envvar_key
   }
 
+  envvar_server <- Sys.getenv("RSCONNECT_SERVER")
+  if (is.null(args$server) && nchar(envvar_server) > 0) {
+    args$server <- envvar_server
+  }
+
   board$server <- args$server
   board$server_name <- if (!is.null(args$server)) gsub("https?://|:[0-9]+/?", "", args$server) else NULL
   board$account <- args$account

--- a/R/pin.R
+++ b/R/pin.R
@@ -51,6 +51,9 @@ pin_default_name <- function(x, board) {
 #' @examples
 #' library(pins)
 #'
+#' # define local board
+#' board_register_local(cache = tempfile())
+#'
 #' # cache the mtcars dataset
 #' pin(mtcars)
 #'
@@ -98,6 +101,9 @@ pin <- function(x, name = NULL, description = NULL, board = NULL, ...) {
 #' @examples
 #'
 #' library(pins)
+#'
+#' # define local board
+#' board_register_local(cache = tempfile())
 #'
 #' # cache the mtcars dataset
 #' pin(mtcars)
@@ -152,10 +158,15 @@ pin_get <- function(name, board = NULL, cache = TRUE, ...) {
 #' @examples
 #'
 #' library(pins)
+#'
+#' # define local board
+#' board_register_local(cache = tempfile())
+#'
+#' # create mtcars pin
 #' pin(mtcars)
 #'
 #' # remove mtcars pin
-#' pin_remove(mtcars, board = "temp")
+#' pin_remove(mtcars, board = "local")
 #' @export
 pin_remove <- function(name, board) {
   board_pin_remove(board_get(board), name)

--- a/man/board_default.Rd
+++ b/man/board_default.Rd
@@ -7,10 +7,15 @@
 board_default()
 }
 \description{
-Retrieves the default board, which defaults to \code{"temp"} but can also be
+Retrieves the default board, which defaults to \code{"local"} but can also be
 configured with the \code{pins.board} option.
 }
 \examples{
+
+library(pins)
+
+# create temp board
+board_register_local("temp")
 
 # configure default board
 options(pind.board = "temp")

--- a/man/board_default.Rd
+++ b/man/board_default.Rd
@@ -15,10 +15,7 @@ configured with the \code{pins.board} option.
 library(pins)
 
 # create temp board
-board_register_local("temp")
-
-# configure default board
-options(pind.board = "temp")
+board_register_local("temp", cache = tempfile())
 
 # retrieve default board
 board_default()

--- a/man/board_default.Rd
+++ b/man/board_default.Rd
@@ -17,6 +17,9 @@ library(pins)
 # create temp board
 board_register_local("temp", cache = tempfile())
 
+# configure default board
+options(pind.board = "temp")
+
 # retrieve default board
 board_default()
 

--- a/man/pin.Rd
+++ b/man/pin.Rd
@@ -35,6 +35,9 @@ continue to work.
 \examples{
 library(pins)
 
+# define local board
+board_register_local(cache = tempfile())
+
 # cache the mtcars dataset
 pin(mtcars)
 

--- a/man/pin_get.Rd
+++ b/man/pin_get.Rd
@@ -28,6 +28,9 @@ all boards and retrieve the one that matches by name.
 
 library(pins)
 
+# define local board
+board_register_local(cache = tempfile())
+
 # cache the mtcars dataset
 pin(mtcars)
 

--- a/man/pin_remove.Rd
+++ b/man/pin_remove.Rd
@@ -22,8 +22,13 @@ remote resources using the tools the board provides.
 \examples{
 
 library(pins)
+
+# define local board
+board_register_local(cache = tempfile())
+
+# create mtcars pin
 pin(mtcars)
 
 # remove mtcars pin
-pin_remove(mtcars, board = "temp")
+pin_remove(mtcars, board = "local")
 }

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -11,3 +11,5 @@ test_board_is_registered <- function(board) {
     FALSE
   })
 }
+
+board_register_local(cache = tempfile())

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -1,3 +1,6 @@
+board_register("local", cache = tempfile(), connect = FALSE)
+board_register("packages", cache = tempfile(), connect = FALSE)
+
 test_board_is_registered <- function(board) {
   tryCatch({
     if (!board %in% board_list()) {
@@ -11,5 +14,3 @@ test_board_is_registered <- function(board) {
     FALSE
   })
 }
-
-board_register_local(cache = tempfile())

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -14,3 +14,12 @@ test_board_is_registered <- function(board) {
     FALSE
   })
 }
+
+test_local_files <- function() {
+  pin_folders <- dir(board_cache_path(), recursive = TRUE)
+
+  if (!identical(pin_folders, character(0)))
+    stop("Found local files: ", paste(pin_folders, collapse = ", "))
+
+  succeed()
+}

--- a/tests/testthat/test-aaa-check.R
+++ b/tests/testthat/test-aaa-check.R
@@ -2,11 +2,5 @@ context("pin aaa check")
 
 test_that("tests start without local dirs", {
   skip_on_cran()
-
-  pin_folders <- dir(board_cache_path())
-
-  if (!identical(pin_folders, character(0)))
-    stop("Found local folders: ", paste(pin_folders, collapse = ", "))
-
-  succeed()
+  test_local_files()
 })

--- a/tests/testthat/test-aaa-check.R
+++ b/tests/testthat/test-aaa-check.R
@@ -1,0 +1,12 @@
+context("pin aaa check")
+
+test_that("tests start without local dirs", {
+  skip_on_cran()
+
+  pin_folders <- dir(board_cache_path())
+
+  if (!identical(pin_folders, character(0)))
+    stop("Found local folders: ", paste(pin_folders, collapse = ", "))
+
+  succeed()
+})

--- a/tests/testthat/test-zzz-check.R
+++ b/tests/testthat/test-zzz-check.R
@@ -2,11 +2,5 @@ context("pin zzz check")
 
 test_that("tests do not create local dirs", {
   skip_on_cran()
-
-  pin_folders <- dir(board_cache_path())
-
-  if (!identical(pin_folders, character(0)))
-    stop("Found local folders: ", paste(pin_folders, collapse = ", "))
-
-  succeed()
+  test_local_files()
 })

--- a/vignettes/boards-understanding.Rmd
+++ b/vignettes/boards-understanding.Rmd
@@ -18,17 +18,13 @@ tibble::tibble(paths = dir(board_local_storage(), full.names = TRUE))
 # A tibble: 2 x 1
    paths                                                
    <chr>                                                
- 1 /private/var/folders/ks/RtmpL6bsZy/file5d7f/temp/data.txt     
- 2 /private/var/folders/ks/RtmpL6bsZy/file5d7f/temp/mtcars            
+ 1 /Users/username/Library/Caches/pins/local/data.txt   
+ 2 /Users/username/Library/Caches/pins/local/mtcars          
 ```
 
-As you can see, each pin is stored inside the temp folder and a list of resources is tracked on a `data.txt` file. The function `pin()` and `pin_get()` store and retrieve data from this well-known location, while `pin_find()` makes use of the index file to search for resources and track other properties like cache expiration information.
-
-To avoid pins being reset aftere your R session restarts, you can register and use a 'local' board and explicitly store or retrieve datasets from this board:
+As you can see, each pin is stored inside the `rappdirs::user_cache_dir()` folder and a list of resources is tracked on a `data.txt` file. The function `pin()` and `pin_get()` store and retrieve data from this well-known location, while `pin_find()` makes use of the index file to search for resources and track other properties like cache expiration information. We can make explicit use of the default "local" board as follows:
 
 ```{r eval=FALSE}
-board_register_local()
-
 pin(mtcars, name = "mtcars", board = "local")
 pin_get("mtcars", board = "local")
 ```

--- a/vignettes/pins-starting.Rmd
+++ b/vignettes/pins-starting.Rmd
@@ -77,10 +77,8 @@ Let's suppose that the 'home prices' dataset is not exactly what we are looking 
 pin("http://www.fhfa.gov/DataTools/Downloads/Documents/HPI/HPI_master.csv")
 ```
 ```
-[1] "/private/var/folders/ks/wm_bx4cn70s6h0r5vgqpsldm0000gn/T/RtmptGupyK/fileca61e837c50/temp/HPI_master/HPI_master.csv"
+[1] "/Users/username/Library/Caches/pins/local/HPI_master/HPI_master.csv"
 ```
-
-> **Note:** We intend the next release of the pins package to use the `rappdirs` package and store data in a persistent cache, see [issues/39](https://github.com/rstudio/pins/issues/39).
 
 Notice that the pin returns a path to a local CSV file, which you are free to load with your favorite package.
 
@@ -148,13 +146,14 @@ options(pins.verbose = TRUE)
 
 After performing a data analysis, you might want to share your dataset with others, which you can achieve using `pin(data, board = "<board-name>")`.
 
-There are multiple boards available, one that can help you share pins with other R sessions and tools it the 'local' board, which stores pins in your local computer. In order to use a local board, you need to register it first:
+There are multiple boards available, one of them is the "local" board which `pins` uses by default. A "local" board can help you share pins with other R sessions and tools using a well-known cache folder in your local computer defined in the `rappdirs` package. Notice that this board is available by default:
 
 ```{r eval=FALSE}
-board_register_local()
+board_list()
 ```
-
-> **Note:** We intend the next release of the pins package to use the `rappdirs` package and store data in a persistent cache to avoid executing `board_register_local()` in each session, see [issues/39](https://github.com/rstudio/pins/issues/39).
+```
+[1] "local"    "packages"
+```
 
 You can also name your boards using the 'name' parameter, when a name is not specified, the `pins` package will simply name your board with the kind of board you are using, 'local' in the previous example.
 
@@ -165,23 +164,23 @@ pin_get("home_price_indexes") %>%
   read_csv(col_types = cols()) %>%
   dplyr::group_by(yr) %>%
   dplyr::count() %>%
-  pin("home_price_analysis", board = "local")
+  pin("home_price_analysis")
 ```
 ```
-## # A tibble: 45 x 2
-##       yr     n
-##    <dbl> <int>
-##  1  1975   274
-##  2  1976   383
-##  3  1977   523
-##  4  1978   689
-##  5  1979   810
-##  6  1980   893
-##  7  1981   885
-##  8  1982   897
-##  9  1983  1005
-## 10  1984  1089
-## # … with 35 more rows
+# A tibble: 45 x 2
+      yr     n
+   <dbl> <int>
+ 1  1975   274
+ 2  1976   383
+ 3  1977   524
+ 4  1978   689
+ 5  1979   812
+ 6  1980   894
+ 7  1981   886
+ 8  1982   898
+ 9  1983  1005
+10  1984  1088
+# … with 35 more rows
 ```
 
 The local board allows you to share pins with other R sessions or even other Python sessions, to share with other people or across different computers, you can consider using the  `github`, `rsconnect` or `kaggle` boards; these boards will be introduced in the [Understanding Boards](boards-github.html) article.

--- a/vignettes/pins-starting.Rmd
+++ b/vignettes/pins-starting.Rmd
@@ -54,17 +54,49 @@ install.packages("pins")
 
 You can discover datasets with `pin_find()`, which by default will search for data inside CRAN packages. The places where `pins` can find or store resources are referred to as 'boards'. There are multiple boards available but they require you to configure them so we will leave those for later on.
 
-As a quick example, let's search for resources that may contain 'home prices':
+As a quick example, let's search for resources that may contain 'boston housing':
 
-```{r}
+```{r eval=FALSE}
 library(pins)
-pin_find("home prices")
+pin_find("boston housing")
+```
+```
+# A tibble: 18,695 x 4
+   name                         description                                     type  board   
+   <chr>                        <chr>                                           <chr> <chr>   
+ 1 A3/housing                   Boston Housing Prices from A3 package.          table packages
+ 2 A3/multifunctionality        Boston Housing Prices from A3 package.          table packages
+ 3 abc.data/musigma2            Boston Housing Prices from abc.data package.    table packages
+ 4 abc.data/ppc                 Boston Housing Prices from abc.data package.    table packages
+ 5 ABC.RAP/annotation_file      Boston Housing Prices from ABC.RAP package.     table packages
+ 6 ABC.RAP/nonspecific_probes   Boston Housing Prices from ABC.RAP package.     table packages
+ 7 ABC.RAP/test_data            Boston Housing Prices from ABC.RAP package.     table packages
+ 8 ABCanalysis/SwissInhabitants Boston Housing Prices from ABCanalysis package. table packages
+ 9 ABCp2/fungus                 Boston Housing Prices from ABCp2 package.       table packages
+10 ABCp2/newt                   Boston Housing Prices from ABCp2 package.       table packages
+# … with 18,685 more rows
 ```
 
 We've found out that the `BSDA` package contains a `Housing` dataset, you can then retrieve this dataset using `pin_get()` as follows:
 
-```{r}
+```{r eval=FALSE}
 pin_get("BSDA/Housing")
+```
+```
+# A tibble: 74 x 3
+   city       year   price
+   <chr>      <fct>  <int>
+ 1 Albany     1984   52400
+ 2 Anaheim    1984  134900
+ 3 Atlanta    1984   64600
+ 4 Baltimore  1984   65200
+ 5 Birmingham 1984   66600
+ 6 Boston     1984  102000
+ 7 Chicago    1984   77500
+ 8 Cincinnati 1984   59600
+ 9 Cleveland  1984   65600
+10 Columbus   1984   60400
+# … with 64 more rows
 ```
 
 Most datasets in CRAN contain rectangular data, which `pins` knows to load as a data frame. Other boards might contain non-rectangular datasets which `pin_get()` also supports. More on this later on, but first, lets introduce caching.


### PR DESCRIPTION
This PR replaces the default `temp` board with the `local` board, which is more appropriate to share data across R sessions and can now be enabled by default since the cache being used is defined by `rappdirs::user_cache_dir()`, which many other R packages already use.