### PR TITLE
Support subpaths and shred pins in RStudio Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.1.2.9001
+Version: 0.1.2.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,26 @@
 # pins 0.1.2.9000 (unreleased)
 
+## RStudio Connect
+
+- Support for retrieving pins shared by others in RStudio
+  Connect boards.
+
+- Support for RStudio Connect servers running undere a
+  subpath in the server.
+
 - Add support for `RSCONNECT_SERVER` environment variable to
   ease configuration of automated RStudio Connect reports.
+
+- Fix intermittent failure to retrieve pins from RStudio
+  Connect boards while creating them.
+
+- Fix in RStudio Connect boards to retrieve pins that match
+  other pin names (#45).
+  
+- Fix for data frames with nested data frames in rsconnect
+  boards (#36).
+  
+## Boards
 
 - Using a board will attempt to automatically register, such
   that `pin(iris, board = "rsconnect")` would work for
@@ -11,21 +30,14 @@
 - Registers "local" board by default, you no longer need to 
   explicitly run `board_register_local()` (#56).
 
-- Fix intermittent failure to retrieve pins from RStudio
-  Connect boards while creating them.
-
-- Fix in RStudio Connect boards to retrieve pins that match
-  other pin names (#45).
-
 - Make use of the `rappdirs` package to define the default
   cache path, replaces `~/.pins`. Use `board_cache_path()`
   to retrieve default cache path.
 
+## Websites
+
 - Fix for data.txt boards created from GitHub boards using
   large files.
-
-- Fix for data frames with nested data frames in rsconnect
-  boards (#36).
 
 # pins 0.1.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,11 @@
-# pins 0.1.2.9000 (unreleased)
+# pins 0.1.3 (unreleased)
 
 ## RStudio Connect
 
 - Support for retrieving pins shared by others in RStudio
   Connect boards.
 
-- Support for RStudio Connect servers running undere a
+- Support for RStudio Connect servers running under a
   subpath in the server.
 
 - Add support for `RSCONNECT_SERVER` environment variable to

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -22,7 +22,7 @@ board_initialize.rsconnect <- function(board, ...) {
   }
 
   board$server <- args$server
-  board$server_name <- if (!is.null(args$server)) gsub("https?://|:[0-9]+/?", "", args$server) else NULL
+  board$server_name <- if (!is.null(args$server)) gsub("https?://|:[0-9]+/?|/.*", "", args$server) else NULL
   board$account <- args$account
   board$output_files <- args$output_files
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -155,7 +155,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
 board_pin_find.rsconnect <- function(board, text = NULL, all_content = FALSE, name = NULL, ...) {
   if (is.null(text)) text <- ""
 
-  if (nchar(text) == 0) {
+  if (nchar(text) == 0 && is.null(name)) {
     # it can be quite slow to list all content in RStudio Connect so we scope to the user content
     account_id <- rsconnect_api_get(board, "/__api__/users/current/")$id
     filter <- paste0("filter=account_id:", account_id, "&accountId:", account_id)

--- a/R/board_rsconnect_token.R
+++ b/R/board_rsconnect_token.R
@@ -23,6 +23,7 @@ rsconnect_token_parse_url <- function(urlText) {
   url$host <- components[[3]]
   url$port <- components[[4]]
   url$path <- components[[5]]
+  url$path_sans_api <- base_path <- gsub("/__api__", "", url$path)
   url
 }
 
@@ -63,7 +64,7 @@ rsconnect_token_headers <- function(board, path, verb, content) {
     writeChar(content, content_file,  eos = NULL, useBytes = TRUE)
   }
 
-  deps$signature_headers(account_info, verb, path, content_file)
+  deps$signature_headers(account_info, verb, paste0(service$path_sans_api, path), content_file)
 }
 
 rsconnect_token_post <- function(board, path, content, encode) {
@@ -87,7 +88,7 @@ rsconnect_token_post <- function(board, path, content, encode) {
                                  parsed$host,
                                  parsed$port,
                                  "POST",
-                                 path,
+                                 paste0(parsed$path_sans_api, path),
                                  rsconnect_token_headers(board, path, "POST", content),
                                  content_type,
                                  content_file)


### PR DESCRIPTION
From @slopp,

```
library(pins)
board_register("rsconnect", server = "https://colorado.rstudio.com/rsc")

# Retrieve Pin
pin_get("alex.gold/bike_rental_stations", board = "rsconnect")
```

Two issues,
1) RStudio Connect boards with subpaths `rsc` are not properly working, other servers work buy there might be redirects in place.
2) Not correctly searching for pins across all users when attempting to retrieve a pin by name.