### PR TITLE
Adjust down max github upload size avoid server error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,11 @@
   
 ## GitHub
 
+- Adjusted max upload file to 25mb to avoid "server error" in
+  the API, larger files than 25mb uploaded as release files. This
+  can be configured using the `pins.github.upload` option, which
+  deefaults to 25.
+
 - Allow overriding GitHub pin over a pin that partially failed
   to be created.
   

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -226,7 +226,7 @@ board_pin_create.github <- function(board, path, name, metadata, ...) {
       yaml::write_yaml(datatxt, file_path)
     }
 
-    if ((file.info(file_path)$size > 5 * 10^7 || release_storage) && !identical(file, "data.txt")) {
+    if ((file.info(file_path)$size > getOption("pins.github.upload", 25) * 10^6 || release_storage) && !identical(file, "data.txt")) {
       if (is.null(release)) release <- github_create_release(board, name)
       download_url <- github_upload_release(board, release, name, file, file_path)
       release_map[[file]] <- download_url


### PR DESCRIPTION
Still hitting "server error" error in the GitHub API while uploading 47mb files, so scoping uploads to 25mb and release files after 25mb.