### PR TITLE
Trigger error when GitHub repo is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
   
 ## GitHub
 
+- `board_register_github()` now checks for the repo to exist (#63).
+
 - Adjusted max upload file to 25mb to avoid "server error" in
   the API, larger files than 25mb uploaded as release files. This
   can be configured using the `pins.github.upload` option, which

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -34,6 +34,12 @@ board_initialize.github <- function(board, token = NULL, repo = NULL, path = "",
   board$path <- if (!is.null(path) && nchar(path) > 0) paste0(path, "/") else ""
   board$branch <- branch
 
+  # check repo exists
+  check_exists <- httr::GET(github_url(board, branch = NULL), github_headers(board))
+  if (httr::http_error(check_exists)) {
+    stop("The repo '", board$repo, "' does not exist or can't be accessed: ", httr::content(check_exists)$message)
+  }
+
   branches <- tryCatch(github_branches(board), error = function(e) e)
   if ("error" %in% class(branches) && grepl("^Git Repository is empty", branches$message)) {
     github_update_index(board, "", "initialize repo", operation = "initialize", branch = "master")

--- a/R/board_registration.R
+++ b/R/board_registration.R
@@ -45,6 +45,11 @@ board_register_local <- function(name = "local",
 #' @param path The subdirectory in the repo where the pins will be stored.
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
 #'
+#' @details
+#'
+#' This function requires a GitHub repo to be manually created; otherwise,
+#' registering a GitHub board will fail.
+#'
 #' @seealso board_register
 #'
 #' @examples

--- a/vignettes/boards-github.Rmd
+++ b/vignettes/boards-github.Rmd
@@ -19,7 +19,7 @@ In order to use GitHub as a [board](boards-understanding.html), you should first
 nchar(Sys.getenv("GITHUB_PAT")) > 0
 ```
 
-If the above statement is `TRUE`, this means GitHub is already configured, which means you can register a GitHub board as follows:
+If the above statement is `TRUE`, this means GitHub is already configured, which means you can register an existing GitHub board as follows. However, when using a new repo, first manually create an empty repo from [github.com/new](https://github.com/new).
 
 ```{r eval=FALSE}
 library(pins)


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/63,

```r
board_register_github(repo = "javierluraschi/foo")
```

triggers,

```
 Error in board_initialize.github(board, ...) : 
  The repo 'javierluraschi/foo' does not exist or can't be accessed: Not Found 
```

and updates docs.