### PR TITLE
Fix to `pin_remove()` for pins with similar names in RSC boards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## RStudio Connect
 
+- Fix issue expanding pins columns in RStudio for pins with
+  similar names in RStudio Connect boards.
+
 - Fix issue removing pins with similar names in RStudio
   Connect boards.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pins 0.2.0.9999 (unreleased)
+
+## RStudio Connect
+
+- Fix issue removing pins with similar names in RStudio
+  Connect boards.
+
 # pins 0.2.0
 
 ## RStudio Connect

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -207,6 +207,7 @@ rsconnect_get_by_name <- function(board, name) {
   only_name <- pin_content_name(name)
 
   details <- board_pin_find(board, name = name_pattern)
+  details <- board_pin_find(board, text = only_name, name = name)
   details <- pin_results_extract_column(details, "content_category")
   details <- pin_results_extract_column(details, "url")
   details <- pin_results_extract_column(details, "guid")

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -152,7 +152,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
   }
 }
 
-board_pin_find.rsconnect <- function(board, text = NULL, all_content = FALSE, name = NULL, ...) {
+board_pin_find.rsconnect <- function(board, text = NULL, name = NULL, all_content = FALSE, ...) {
   if (is.null(text)) text <- ""
 
   if (nchar(text) == 0 && is.null(name)) {
@@ -169,7 +169,10 @@ board_pin_find.rsconnect <- function(board, text = NULL, all_content = FALSE, na
 
   entries <- lapply(entries, function(e) { e$name <- paste(e$owner_username, e$name, sep = "/") ; e })
 
-  if (!is.null(name)) entries <- Filter(function(e) grepl(name, e$name), entries)
+  if (!is.null(name)) {
+    name_pattern <- if (grepl("/", name)) paste0("^", name, "$") else paste0(".*/", name, "$")
+    entries <- Filter(function(e) grepl(name_pattern, e$name), entries)
+  }
 
   results <- pin_results_from_rows(entries)
 
@@ -203,16 +206,12 @@ board_pin_find.rsconnect <- function(board, text = NULL, all_content = FALSE, na
 }
 
 rsconnect_get_by_name <- function(board, name) {
-  name_pattern <- if (grepl("/", name)) paste0("^", name, "$") else paste0(".*/", name, "$")
   only_name <- pin_content_name(name)
 
-  details <- board_pin_find(board, name = name_pattern)
   details <- board_pin_find(board, text = only_name, name = name)
   details <- pin_results_extract_column(details, "content_category")
   details <- pin_results_extract_column(details, "url")
   details <- pin_results_extract_column(details, "guid")
-
-  details <- details[grepl(name_pattern, details$name),]
 
   if (nrow(details) > 1) {
     details <- details[details$owner_username == board$account,]

--- a/R/board_test.R
+++ b/R/board_test.R
@@ -71,7 +71,13 @@ board_test <- function(board, exclude = list()) {
     result <- pin_remove(pin_name, board = board)
     deps$expect_equal(result, NULL)
 
+    results <- pin_find(name = pin_name, board = board)
+    deps$expect_equal(nrow(results), 0)
+
     result <- pin_remove(dataset_name, board = board)
     deps$expect_equal(result, NULL)
+
+    results <- pin_find(name = dataset_name, board = board)
+    deps$expect_equal(nrow(results), 0)
   })
 }

--- a/R/pin.R
+++ b/R/pin.R
@@ -243,7 +243,7 @@ pin_find <- function(text = NULL, board = NULL, name = NULL, ...) {
     board_object <- board_get(board_name)
 
     board_pins <- tryCatch(
-      board_pin_find(board = board_object, text, ...),
+      board_pin_find(board = board_object, text, name = name, ...),
       error = function(e) {
         warning("Error searching '", board_name, "' board: ", e$message)
         board_empty_results()

--- a/R/pin.R
+++ b/R/pin.R
@@ -188,6 +188,7 @@ pin_find_empty <- function() {
 #'
 #' @param text The text to find in the pin description or name.
 #' @param board The board name used to find the pin.
+#' @param name The exact name of the pin to match when searching.
 #' @param ... Additional parameters.
 #'
 #' @details
@@ -231,7 +232,7 @@ pin_find_empty <- function() {
 #' }
 #'
 #' @export
-pin_find <- function(text = NULL, board = NULL, ...) {
+pin_find <- function(text = NULL, board = NULL, name = NULL, ...) {
   if (is.null(board) || nchar(board) == 0) board <- board_list()
   metadata <- identical(list(...)$metadata, TRUE)
   text <- pin_content_name(text)
@@ -263,9 +264,8 @@ pin_find <- function(text = NULL, board = NULL, ...) {
     all_pins <- all_pins[, names(all_pins) != "metadata"]
   }
 
-  if (!is.null(list(...)$name)) {
-    name <- list(...)$name
-    all_pins <- all_pins[all_pins$name == name,]
+  if (!is.null(name)) {
+    all_pins <- all_pins[grepl(paste0("(.*/)?", name, "$"), all_pins$name),]
     if (nrow(all_pins) > 0) all_pins <- all_pins[1,]
   }
 

--- a/R/ui_viewer.R
+++ b/R/ui_viewer.R
@@ -81,7 +81,7 @@ ui_viewer_register <- function(board, board_call) {
       attr_names <- c()
       attr_values <- c()
 
-      pin_index <- pin_find(table, board = board$name, metadata = TRUE)
+      pin_index <- pin_find(table, board = board$name, name = table, metadata = TRUE)
       pin_index <- pin_index[table == pin_index$name,]
 
       if (!is.null(pin_index$metadata) || nchar(pin_index$metadata) > 0) {

--- a/man/pin_find.Rd
+++ b/man/pin_find.Rd
@@ -4,12 +4,14 @@
 \alias{pin_find}
 \title{Find Pin}
 \usage{
-pin_find(text = NULL, board = NULL, ...)
+pin_find(text = NULL, board = NULL, name = NULL, ...)
 }
 \arguments{
 \item{text}{The text to find in the pin description or name.}
 
 \item{board}{The board name used to find the pin.}
+
+\item{name}{The exact name of the pin to match when searching.}
 
 \item{...}{Additional parameters.}
 }


### PR DESCRIPTION
In RStudio Connect boards when pins have similar names, for example `iris` and `iris-lm`, both where being retrieved by internal APIs and the pin not properly removed. Fix on its way.