### PR TITLE
Support absolute paths for datatxt boards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.2.0.0004
+Version: 0.2.0.0005
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -57,7 +57,12 @@ board_pin_get.datatxt <- function(board, name, extract = NULL, ...) {
 
     # try to download index as well
     path_guess <- if (grepl(".*/.*\\.[a-zA-Z]+$", index[[1]]$path[1])) dirname(index[[1]]$path[1]) else index[[1]]$path[1]
-    download_path <- file.path(board$url, path_guess, "data.txt")
+    # if `path_guess` already has a scheme, don't prepend board URL
+    download_path <- if (grepl("^https?://", path_guess)) {
+      file.path(path_guess, "data.txt")
+    } else {
+      file.path(board$url, path_guess, "data.txt")
+    }
     pin_download(download_path, name, board$name, can_fail = TRUE, headers = board_headers(board, download_path))
 
     manifest <- pin_manifest_get(local_path)


### PR DESCRIPTION
Currently we're assuming paths given in the `data.txt` for a datatxt board are relative so we prepend the board URL to download paths. With this PR we check first to see if a proper URL (http/https) is given.