### PR TITLE
Switch from Kaggle -> Azure for azure documentation

### DIFF
--- a/vignettes/boards-azure.Rmd
+++ b/vignettes/boards-azure.Rmd
@@ -37,14 +37,14 @@ Once the board is registered, you can pin and search using `pin()`, `pin_get()` 
 
 ## Pinning
 
-Like in other boards, you can create pins for `iris` and `mtcars` by setting `board` to Kaggle's board name,
+Like in other boards, you can create pins for `iris` and `mtcars` by setting `board` to Azure's board name,
 
 ```{r eval=FALSE}
 pin(iris, description = "The iris data set", board = "azure")
 pin(mtcars, description = "The motor trend cars data set", board = "azure")
 ```
 
-After a pin is created, the pin also becomes available in the Kaggle's dataset website; by default, they are created as private datasets.
+After a pin is created, the pin also becomes available in the Azure's dataset website; by default, they are created as private datasets.
 
 ![](images/boards-azure-storage-pin.png){width=480px}
 


### PR DESCRIPTION
Fixing up docs, looks like you adapted the Kaggle vignette for Azure. Found two cases where Kaggle was referred to, switched them to Azure.