### PR TITLE
Pass through account to wrapper for Azure

### DIFF
--- a/R/board_registration.R
+++ b/R/board_registration.R
@@ -283,6 +283,7 @@ board_register_azure <- function(name = "azure",
                                  ...) {
   board_register("azure",
                  name = name,
+                 account = account,
                  container = container,
                  cache = cache,
                  ...)


### PR DESCRIPTION
When testing `pins::board_register_azure()` it seems the wrapper wasn't passing the account string through. I think this proposed PR will fix that (untested).

Example of what is/isn't working for me:
![image](https://user-images.githubusercontent.com/119403/68801410-ed1fe780-06c0-11ea-84fc-ab795bb075cb.png)
