### PR TITLE
Ensure pin_find() retrieves all pins in RStudio Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.2.0.0009
+Version: 0.2.0.0010
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,12 @@
 
 ## RStudio Connect
 
+- Fix issue where `pin_find()` would not show all available
+  pins.
+
+- Fix issue where RStudio Connections pane would not show
+  all pins.
+
 - Store all downloaded content under user subfolder insited 
   rsconnect cache.
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -38,6 +38,8 @@ board_initialize.rsconnect <- function(board, ...) {
     board <- rsconnect_token_initialize(board)
   }
 
+  board$pins_supported <- tryCatch(rsconnect_pins_supported(board), error = function(e) FALSE)
+
   board
 }
 
@@ -163,8 +165,11 @@ board_pin_find.rsconnect <- function(board,
   if (!is.null(name)) text <- pin_content_name(name)
 
   filter <- paste0("search=", text)
+  content_filter <- ""
 
-  entries <- rsconnect_api_get(board, paste0("/__api__/applications/?", utils::URLencode(filter)))$applications
+  if (identical(board$pins_supported, TRUE)) content_filter <- "filter=content_type:pin&"
+
+  entries <- rsconnect_api_get(board, paste0("/__api__/applications/?", content_filter, utils::URLencode(filter)))$applications
   if (!all_content) entries <- Filter(function(e) e$content_category == "pin", entries)
 
   entries <- lapply(entries, function(e) { e$name <- paste(e$owner_username, e$name, sep = "/") ; e })

--- a/R/board_rsconnect_api.R
+++ b/R/board_rsconnect_api.R
@@ -16,7 +16,7 @@ rsconnect_api_auth_headers <- function(board, path, verb, content = NULL) {
 }
 
 rsconnect_api_version <- function(board) {
-  jsonlite::fromJSON(rsconnect_api_get(board, "/server_settings")$content)$version
+  rsconnect_api_get(board, "/__api__/server_settings")$version
 }
 
 rsconnect_api_get <- function(board, path) {


### PR DESCRIPTION
Previous versions of RSC did not supported `pins` so we were not using the `pins` content type while searching, this is now supported and unblocks cases where pins are not retrieved due to many results that are not pins.

<img width="1440" alt="Screen Shot 2019-11-25 at 11 10 07 AM" src="https://user-images.githubusercontent.com/3478847/69570231-47982e00-0f74-11ea-9737-88499063fa67.png">
