### PR TITLE
Suggest correct registration code in RStudio connections pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# pins 0.3.0.9003
+# pins 0.3.0.9004
 
 ## Pins
 
@@ -13,6 +13,8 @@
 - Added missing `key` parameter in `board_register_azure()`.
 
 ## RStudio
+
+- Fixed connection suggested code when caused by `pin_find()` (#137).
 
 - Fixed connection launcher for Azure connections.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# pins 0.3.0.9002
+# pins 0.3.0.9003
 
 ## Pins
+
+- `pin_info()` prints long character strings in their own line.
 
 - Fixed issue in `pin_remove()` for S3, Azure, GCloud, Google and website boards (#138).
 

--- a/R/board.R
+++ b/R/board.R
@@ -107,12 +107,16 @@ board_get <- function(name) {
   if (!name %in% board_registry_list()) {
     board_inferred <- board_infer(name)
 
+    if (!is.null(board_inferred$register_call)) {
+      register_call <- board_inferred$register_call
+    }
+
     # attempt to automatically register board
     name <- board_inferred$name
     tryCatch(board_register(board_inferred$board,
                             name = board_inferred$name,
                             connect = board_inferred$connect,
-                            register_call = board_inferred$register_call,
+                            register_call = register_call,
                             url = board_inferred$url),
              error = function(e) NULL)
 

--- a/R/pin.R
+++ b/R/pin.R
@@ -383,24 +383,35 @@ print_pin_info <- function(name, e, ident) {
   # one-row data frames are better displayed as lists
   if (is.data.frame(e) && nrow(e) == 1) e <- as.list(e)
 
+  name_prefix <- if (!is.null(name) && nchar(name) > 0) paste0(name, ": ") else ""
+
   if (!is.list(e) && is.vector(e)) {
-    cat(crayon::silver(paste0("#", ident, "- ", name, ": ", paste(e, collapse = ", "), "\n")))
+    # Long strings (like paths) print better on their own line
+    if (length(e) > 1 && is.character(e) && max(nchar(e)) > 20) {
+      cat(crayon::silver(paste0("#", ident, "- ", name_prefix, "\n")))
+      for (i in e) {
+        print_pin_info("", i, paste0(ident, "  "))
+      }
+    }
+    else {
+      cat(crayon::silver(paste0("#", ident, "- ", name_prefix, paste(e, collapse = ", "), "\n")))
+    }
   }
   else if (is.data.frame(e)) {
-    cat(crayon::silver(paste0("#", ident, "- ", name, ": ")))
+    cat(crayon::silver(paste0("#", ident, "- ", name_prefix)))
     if (length(colnames(e)) > 0) cat(crayon::silver(paste0("(", colnames(e)[[1]], ") ")))
     cat(crayon::silver(paste(e[,1], collapse = ", ")))
     if (length(colnames(e)) > 1) cat(crayon::silver("..."))
     cat(crayon::silver("\n"))
   }
   else if (is.list(e)) {
-    cat(crayon::silver(paste0("#", ident, "- ", name, ": \n")))
+    cat(crayon::silver(paste0("#", ident, "- ", name_prefix, "\n")))
     for (i in names(e)) {
       print_pin_info(i, e[[i]], paste0(ident, "  "))
     }
   }
   else {
-    cat(crayon::silver(paste0("#", ident, "- ", name, ": ", class(e)[[1]], "\n")))
+    cat(crayon::silver(paste0("#", ident, "- ", name_prefix, class(e)[[1]], "\n")))
   }
 }
 


### PR DESCRIPTION
`pin_find()` was causing some boards to register with `board_get()` in the connections pane. Fixes https://github.com/rstudio/pins/issues/137.