### PR TITLE
Properly expose error messages when pin fails to create in rsconnect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.0.9001
+Version: 0.3.0.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## RStudio Connect
 
+- Improve error messages when a pin fails to be created (#149).
+
 - Added support for `CONNECT_API_KEY` and `CONNECT_SERVER` in place of
   `RSCONNECT_API` and `RSCONNECT_SERVER`, which they are still supported
   for backwards-compatibility.

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -103,6 +103,10 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
                                       name = name,
                                       description = board_metadata_to_text(metadata, metadata$description)
                                     ))
+
+      if (!is.null(content$error)) {
+        stop("Failed to create pin: ", content$error)
+      }
     }
 
     files <- lapply(dir(temp_dir, recursive = TRUE, full.names = TRUE), function(path) {


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/149