### PR TITLE
Properly support registering rsconnect with trails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.0.9002
+Version: 0.3.0.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 ## RStudio Connect
 
+- Fix issue affecting boards registered with trailing slash (#151).
+
 - Improve error messages when a pin fails to be created (#149).
 
 - Added support for `CONNECT_API_KEY` and `CONNECT_SERVER` in place of

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -21,8 +21,10 @@ board_initialize.rsconnect <- function(board, ...) {
     args$server <- envvar_server
   }
 
-  board$server <- args$server
-  board$server_name <- if (!is.null(args$server)) gsub("https?://|:[0-9]+/?|/.*", "", args$server) else NULL
+  if (!is.null(args$server)) {
+    board$server <-  gsub("/$", "", args$server)
+    board$server_name <- gsub("https?://|:[0-9]+/?|/.*", "", args$server)
+  }
   board$account <- args$account
   board$output_files <- args$output_files
 

--- a/tests/testthat/test-board-rsconnect.R
+++ b/tests/testthat/test-board-rsconnect.R
@@ -1,5 +1,16 @@
 context("board rsc")
 
+test_rsconnect_boards <- function(key, server) {
+  board_register("rsconnect",
+                 key = key,
+                 server = server,
+                 cache = tempfile())
+
+  board_test("rsconnect", destination = server)
+
+  board_deregister("rsconnect")
+}
+
 if (test_board_is_registered("rsconnect")) {
   board_test("rsconnect")
 } else {
@@ -11,14 +22,12 @@ if (test_board_is_registered("rsconnect")) {
     if (length(rsc_servers) != length(rsc_apis)) stop("Incorrect length for TEST_RSCONNECT_SERVER and RSCONNECT_API.")
 
     for (rsc_index in seq_along(rsc_servers)) {
-      board_register("rsconnect",
-                     key = rsc_apis[[rsc_index]],
-                     server = rsc_servers[[rsc_index]],
-                     cache = tempfile())
+      server <- gsub("/$", "", rsc_servers[[rsc_index]])
 
-      board_test("rsconnect", destination = paste0(rsc_servers[[rsc_index]]))
+      test_rsconnect_boards(rsc_apis[[rsc_index]], server)
 
-      board_deregister("rsconnect")
+      # also test with trailing slash
+      test_rsconnect_boards(rsc_apis[[rsc_index]], paste0(server, "/"))
     }
   } else {
     test_that("can't register rsconnect board", {


### PR DESCRIPTION
It has been reported problems when a board is registered with trailing slashes, the `pins` codebase assumes no trailing slash, so this fix simply removes the trail when a board is registered and runs all tests with and without registering using a trailing slash.