### PR TITLE
Fix large uploads when using rsconnect board

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.0.9003
+Version: 0.3.0.9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@
 
 ## RStudio Connect
 
+- Fix issue uploading large pins causing `is.character(type) is not TRUE`
+  error.
+
 - Fix issue affecting boards registered with trailing slash (#151).
 
 - Improve error messages when a pin fails to be created (#149).

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -138,8 +138,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
 
     upload <- rsconnect_api_post(board,
                                  paste0("/__api__/v1/experimental/content/", guid, "/upload"),
-                                 httr::upload_file(normalizePath(bundle),
-                                                   type = "application/gzip"),
+                                 httr::upload_file(normalizePath(bundle)),
                                  progress = http_utils_progress("up", size = file.info(normalizePath(bundle))$size))
 
     if (!is.null(upload$error)) {

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -139,8 +139,8 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
     upload <- rsconnect_api_post(board,
                                  paste0("/__api__/v1/experimental/content/", guid, "/upload"),
                                  httr::upload_file(normalizePath(bundle),
-                                                   http_utils_progress("up", size = file.info(normalizePath(bundle))$size)),
-                                 http_utils_progress("up"))
+                                                   type = "application/gzip"),
+                                 progress = http_utils_progress("up", size = file.info(normalizePath(bundle))$size))
 
     if (!is.null(upload$error)) {
       stop("Failed to upload pin: ", upload$error)

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -143,6 +143,9 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
                                  progress = http_utils_progress("up", size = file.info(normalizePath(bundle))$size))
 
     if (!is.null(upload$error)) {
+      # before we fail, clean up rsconnect content
+      rsconnect_api_delete(board, paste0("/__api__/v1/experimental/content/", guid))
+
       stop("Failed to upload pin: ", upload$error)
     }
 


### PR DESCRIPTION
Create 70mb file,

```r
saveRDS(matrix(rnorm(10 * 10^6), ncol = 10), "size-70mb.rds")
```

Uploading this file as a pin causes error due to typo in `pins 0.3.0` release,

```r
pin("size-70mb.rds", "size-70mb", board = "rsconnect")
```
```
Error in curl::form_file(path, type) : is.character(type) is not TRUE
```