### PR TITLE
Gracefully handle errors when a pin's preview can't be created in rsconnect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.0.9004
+Version: 0.3.0.9005
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,8 @@
   
 ## RStudio
 
+- Gracefully handle errors when a pin's preview can't be created.
+
 - Website boards now support the browse menu item in the connection.
 
 - Fix data frames previewing character columns with special

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -66,7 +66,21 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, ...) {
   }
 
   file.copy(dir(path, full.names = TRUE), temp_dir)
-  data_files <- rsconnect_bundle_create(x, temp_dir, name, board, account_name)
+  data_files <- tryCatch({
+    rsconnect_bundle_create(x, temp_dir, name, board, account_name)
+    stop("blah")
+  }, error = function(e) {
+    NULL
+  })
+
+  # handle unexepcted failures gracefully
+  if (is.null(data_files)) {
+    warning("Falied to create preview files for pin.")
+    unlink(temp_dir, recursive = TRUE)
+    dir.create(temp_dir, recursive = TRUE)
+    file.copy(dir(path, full.names = TRUE), temp_dir)
+    data_files <- rsconnect_bundle_create.default(x, temp_dir, name, board, account_name)
+  }
 
   rsconnect_is_authenticated <- function(board) {
     !is.null(board$key) || !is.null(board$account)


### PR DESCRIPTION
A pin in rsconnect boards might fail to create a preview, we should not fail the entire operation but rather create the default assets and warn of the problem.