### PR TITLE
Support for metadata in pin_info()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.1
+Version: 0.3.1.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# pins 0.3.1.9000
+
+## Pins
+
+- `pin_info()` adds support for `metadata` parameter to avoid retrieving pin contents.
+
 # pins 0.3.1
 
 ## Pins

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -181,6 +181,7 @@ board_pin_find.rsconnect <- function(board,
                                      name = NULL,
                                      all_content = FALSE,
                                      extended = FALSE,
+                                     metadata = FALSE,
                                      ...) {
   if (is.null(text)) text <- ""
   if (!is.null(name)) text <- pin_content_name(name)
@@ -200,9 +201,6 @@ board_pin_find.rsconnect <- function(board,
     entries <- Filter(function(e) grepl(name_pattern, e$name), entries)
   }
 
-  if (identical(extended, TRUE))
-    return(pin_entries_to_dataframe(entries))
-
   results <- pin_results_from_rows(entries)
 
   if (nrow(results) == 0) {
@@ -215,7 +213,7 @@ board_pin_find.rsconnect <- function(board,
   results$name <- as.character(results$name)
   results$type <- unname(sapply(results$description, function(e) null_or_value(board_metadata_from_text(e)$type, "files")))
 
-  if (!identical(extended, TRUE)) {
+  if (identical(metadata, TRUE)) {
     results$metadata <- sapply(results$description, function(e) as.character(jsonlite::toJSON(board_metadata_from_text(e), auto_unbox = TRUE)))
   }
 
@@ -227,12 +225,21 @@ board_pin_find.rsconnect <- function(board,
     etag <- as.character(entries[[1]]$last_deployed_time)
 
     local_path <- rsconnect_api_download(board, entries[[1]]$name, file.path(remote_path, "data.txt"), etag = etag)
-    manifest <- pin_manifest_get(local_path)
 
-    manifest <- c(entries[[1]], manifest)
+    manifest <- list()
+    if (identical(metadata, TRUE)) {
+      manifest <- pin_manifest_get(local_path)
+    }
+
+    if (identical(extended, TRUE)) {
+      manifest <- c(entries[[1]], manifest)
+    }
 
     results$type <- manifest$type
-    results$metadata <- as.character(jsonlite::toJSON(manifest, auto_unbox = TRUE))
+
+    if (identical(metadata, TRUE)) {
+      results$metadata <- as.character(jsonlite::toJSON(manifest, auto_unbox = TRUE))
+    }
   }
 
   results

--- a/man/pin_info.Rd
+++ b/man/pin_info.Rd
@@ -4,14 +4,16 @@
 \alias{pin_info}
 \title{Pin Info}
 \usage{
-pin_info(name, board = NULL, extended = TRUE, ...)
+pin_info(name, board = NULL, extended = TRUE, metadata = TRUE, ...)
 }
 \arguments{
 \item{name}{The exact name of the pin to match when searching.}
 
 \item{board}{The board name used to find the pin.}
 
-\item{extended}{Should additional board-specific colulmns be shown?}
+\item{extended}{Should additional board-specific information be shown?}
+
+\item{metadata}{Should additional pin-specific information be shown?}
 
 \item{...}{Additional parameters.}
 }

--- a/tests/testthat/test-pin-info.R
+++ b/tests/testthat/test-pin-info.R
@@ -9,3 +9,33 @@ test_that("can retrieve pin_info() across all boards", {
   expect_equal(entries$type, "table")
   expect_equal(as.character(entries$rows), "150")
 })
+
+test_that("can retrieve pin_info() with no extended info across all boards", {
+  pin(iris, "iris")
+
+  entries <- pin_info("iris", extended = FALSE)
+
+  expect_equal(entries$name, "iris")
+  expect_equal(entries$type, "table")
+  expect_equal(as.character(entries$rows), "150")
+})
+
+test_that("can retrieve pin_info() with no metadata info across all boards", {
+  pin(iris, "iris")
+
+  entries <- pin_info("iris", metadata = FALSE)
+
+  expect_equal(entries$name, "iris")
+  expect_equal(entries$type, "table")
+  expect_equal(as.character(entries$rows), "150")
+})
+
+test_that("can retrieve pin_info() with no extended nor metadata info across all boards", {
+  pin(iris, "iris")
+
+  entries <- pin_info("iris", extended = FALSE, metadata = FALSE)
+
+  expect_equal(entries$name, "iris")
+  expect_equal(entries$type, "table")
+  expect_equal(as.character(entries$rows), "150")
+})

--- a/tests/testthat/test-pin-info.R
+++ b/tests/testthat/test-pin-info.R
@@ -27,7 +27,7 @@ test_that("can retrieve pin_info() with no metadata info across all boards", {
 
   expect_equal(entries$name, "iris")
   expect_equal(entries$type, "table")
-  expect_equal(as.character(entries$rows), "150")
+  expect_equal("rows" %in% colnames(entries$rows), FALSE)
 })
 
 test_that("can retrieve pin_info() with no extended nor metadata info across all boards", {
@@ -37,5 +37,5 @@ test_that("can retrieve pin_info() with no extended nor metadata info across all
 
   expect_equal(entries$name, "iris")
   expect_equal(entries$type, "table")
-  expect_equal(as.character(entries$rows), "150")
+  expect_equal("rows" %in% colnames(entries$rows), FALSE)
 })


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/160, adds support for `metadata = FALSE` in `pin_info()` to avoid attempting to retrieve pin's content. This can be useful when admins are using `pin_info()` to understand a pin they don't have access to.

This feature can be installed as follows:

```r
remotes::install_github("rstudio/pins", ref = "bugfix/pin-info-metadata")
```