### PR TITLE
Support installing pins from Jupyter

### DIFF
--- a/python/pins/__init__.py
+++ b/python/pins/__init__.py
@@ -230,7 +230,8 @@ def pin(x, name, description = "", board = None):
       _build_call("pins::pin", {
         'x': { 'code': "feather::read_feather(\"" + path + "\")" },
         'name': name,
-        'description': description }) +
+        'description': description,
+        'board': board }) +
       ", \"" + path + "\")")
     result = _from_feather(path)
     os.remove(path)

--- a/python/pins/__init__.py
+++ b/python/pins/__init__.py
@@ -9,6 +9,7 @@ import platform
 import sys
 
 rlib = None
+pins_init = False
 
 def _get_rhome():
     r_home = os.environ.get("R_HOME")
@@ -160,17 +161,22 @@ def _build_call(function, params):
   return call
   
 def _init_pins():
+  global pins_init
+  
+  if not pins_init:
     r_start()
-    r_eval("""
-        if (length(find.package("pins", quiet = TRUE)) == 0) {
-          install.packages("pins", version = "0.3.1", repos = pins:::packages_repo_default())
-        }
-        
-        if (length(find.package("feather", quiet = TRUE)) == 0) {
-          install.packages("feather", repos = pins:::packages_repo_default())
-        }
-    """)
+    pins_installed = r_eval("as.character(length(find.package('pins', quiet = TRUE)) > 0)")
+    feather_installed = r_eval("as.character(length(find.package('feather', quiet = TRUE)) > 0)")
+    
+    if pins_installed != "TRUE":
+      r_eval("install.packages('pins', version = '0.3.1', repos = pins:::packages_repo_default())")
+    
+    if feather_installed != "TRUE":
+      r_eval("install.packages('feather', repos = pins:::packages_repo_default())")
+
+    _print("loading pins package")
     r_eval("library('pins')")
+    pins_init = True
     
 def _from_arrow(buffer):
     import pyarrow as pa

--- a/tests/testthat/test-board-packages.R
+++ b/tests/testthat/test-board-packages.R
@@ -14,7 +14,7 @@ test_that("can pin_find() packages with search term", {
 
 test_that("can pin_get() an specific resource", {
   expect_gt(
-    nrow(pin_get("hpiR/seattle_sales", board = "packages")),
+    nrow(pin_get("babynames/babynames", board = "packages")),
     10^4
   )
 })


### PR DESCRIPTION
<img width="1169" alt="Screen Shot 2020-01-20 at 12 50 00 PM" src="https://user-images.githubusercontent.com/3478847/72756862-6f2a0200-3b83-11ea-8547-73e4094199ad.png">

Python / Jupyer code:

```python
pip install git+https://github.com/rstudio/pins.git@bugfix/python-install#subdirectory=python

import pins
pins.pin_get("hpiR/seattle_sales")

import pandas as pd
import numpy as np

data = np.array([['','Col1','Col2'],
                ['Row1',1,2],
                ['Row2',3,4]])

data = pd.DataFrame(data=data[1:,1:], index=data[1:,0], columns=data[0,1:])
data

pins.board_register("rsconnect", server = "https://connect.rstudioservices.com",
                                 key = "APIKEY")

pins.pin(data, "jupyter-test", board = "rsconnect")
```