### PR TITLE
Improve error message in rsconnect boards with dupe names to fix #171

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.2.9000
+Version: 0.3.2.9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `pin()` now refreshes the connections pane.
 
+## RStudio Connect
+
+- Improve error message for `pin_get()` with duplicate names (#171).
+
 # pins 0.3.2
 
 ## Pins

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -254,11 +254,15 @@ rsconnect_get_by_name <- function(board, name) {
   details <- pin_results_extract_column(details, "guid")
 
   if (nrow(details) > 1) {
-    details <- details[details$owner_username == board$account,]
+    owner_details <- details[details$owner_username == board$account,]
+    if (nrow(owner_details) == 1) {
+      details <- owner_details
+    }
   }
 
   if (nrow(details) > 1) {
-    stop("Multiple pins named '", name, "' in board '", board$name, "'")
+    stop("Multiple pins named '", name, "' in board '", board$name,
+         "', choose from: ", paste0("'", paste0(details$name, collapse = "', '"), "'."))
   }
 
   details


### PR DESCRIPTION
Currently,

```r
pin_get("iris", board = "rsconnect")
```
```
 Error in board_pin_get.rsconnect(board_get(board), name, extract = extract,  : 
  The pin 'iris' is not available in the 'rsconnect' board. 
```

This PR,

```r
pin_get("iris", board = "rsconnect")
```
```
Error in rsconnect_get_by_name(board, name) : 
  Multiple pins named 'iris' in board 'rsconnect', choose from: 'cole/iris', 'nathan/iris', 'mark/iris'. 
```