### PR TITLE
Support for GitHub Enterprise

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.2.9001
+Version: 0.3.2.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@
 
 - Improve error message for `pin_get()` with duplicate names (#171).
 
+## GitHub
+
+- Support for custom GitHub hosts including GitHub Enterprise using the
+  `host` parameter in `board_register_github()` (#163).
+
 # pins 0.3.2
 
 ## Pins

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -362,7 +362,7 @@ github_branches_create <- function(board, new_branch, base_branch) {
 github_content_url <- function(board, branch = board$branch, ...) {
   args <- list(...)
 
-  url <- paste0(bost$host, "/repos/", board$repo, "/contents/", paste0(board$path, paste0(args, collapse = "")))
+  url <- paste0(board$host, "/repos/", board$repo, "/contents/", paste0(board$path, paste0(args, collapse = "")))
   if (!is.null(branch))
     url <- paste0(url, "?ref=", branch)
 

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -17,7 +17,14 @@ github_headers <- function(board) {
   httr::add_headers(Authorization = paste("token", github_auth(board)))
 }
 
-board_initialize.github <- function(board, token = NULL, repo = NULL, path = "", branch = "master", overwrite = FALSE, ...) {
+board_initialize.github <- function(board,
+                                    token = NULL,
+                                    repo = NULL,
+                                    path = "",
+                                    branch = "master",
+                                    overwrite = FALSE,
+                                    host = "https://api.github.com",
+                                    ...) {
   if (!github_authenticated(board)) {
     if (is.null(token)) {
       stop("GitHub Personal Access Token must be specified with the 'token' parameter or with the 'GITHUB_PAT' ",
@@ -33,6 +40,7 @@ board_initialize.github <- function(board, token = NULL, repo = NULL, path = "",
   board$repo <- repo
   board$path <- if (!is.null(path) && nchar(path) > 0) paste0(path, "/") else ""
   board$branch <- branch
+  board$host <- host
 
   # check repo exists
   check_exists <- httr::GET(github_url(board, branch = NULL), github_headers(board))
@@ -303,7 +311,7 @@ board_pin_find.github <- function(board, text, ...) {
 github_url <- function(board, branch = board$branch, ...) {
   args <- list(...)
 
-  url <- paste0("https://api.github.com/repos/", board$repo, paste0(args, collapse = ""))
+  url <- paste0(board$host, "/repos/", board$repo, paste0(args, collapse = ""))
   if (!is.null(branch))
     url <- paste0(url, "?ref=", branch)
 
@@ -354,7 +362,7 @@ github_branches_create <- function(board, new_branch, base_branch) {
 github_content_url <- function(board, branch = board$branch, ...) {
   args <- list(...)
 
-  url <- paste0("https://api.github.com/repos/", board$repo, "/contents/", paste0(board$path, paste0(args, collapse = "")))
+  url <- paste0(bost$host, "/repos/", board$repo, "/contents/", paste0(board$path, paste0(args, collapse = "")))
   if (!is.null(branch))
     url <- paste0(url, "?ref=", branch)
 

--- a/R/board_registration.R
+++ b/R/board_registration.R
@@ -46,6 +46,7 @@ board_register_local <- function(name = "local",
 #' @param branch The branch to use when commiting pins.
 #' @param token Token to use when \code{GITHUB_PAT} is not specified.
 #' @param path The subdirectory in the repo where the pins will be stored.
+#' @param host The URL hosting the GitHub API, defaults to \code{"https://api.github.com"}.
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
 #' @param ... Additional parameters required to initialize a particular board.
 #'
@@ -58,6 +59,9 @@ board_register_local <- function(name = "local",
 #' they support up to 2GB file uploads. This threshold can be configured through
 #' the \code{pins.github.release} option which is specified in megabytes and
 #' defaults to \code{25}.
+#'
+#' When using GitHub Enterprise, consider customizing the \code{host} parameter to
+#' \code{"https://yourhostname/api/v3"}.
 #'
 #' @seealso board_register
 #'
@@ -72,6 +76,7 @@ board_register_github <- function(name = "github",
                                   branch = "master",
                                   token = NULL,
                                   path = "",
+                                  host = "https://api.github.com",
                                   cache = board_cache_path(),
                                   ...) {
   board_register("github", name = name,
@@ -80,6 +85,7 @@ board_register_github <- function(name = "github",
                            token = token,
                            path = path,
                            cache = cache,
+                           host = host,
                            ...)
 }
 

--- a/man/board_register_github.Rd
+++ b/man/board_register_github.Rd
@@ -6,7 +6,7 @@
 \usage{
 board_register_github(name = "github", repo = NULL,
   branch = "master", token = NULL, path = "",
-  cache = board_cache_path(), ...)
+  host = "https://api.github.com", cache = board_cache_path(), ...)
 }
 \arguments{
 \item{name}{Optional name for this board, defaults to 'github'.}
@@ -19,6 +19,8 @@ board_register_github(name = "github", repo = NULL,
 \item{token}{Token to use when \code{GITHUB_PAT} is not specified.}
 
 \item{path}{The subdirectory in the repo where the pins will be stored.}
+
+\item{host}{The URL hosting the GitHub API, defaults to \code{"https://api.github.com"}.}
 
 \item{cache}{The local folder to use as a cache, defaults to \code{board_cache_path()}.}
 
@@ -36,6 +38,9 @@ When a file upload exceeds 25MB, a GitHub release file will be used since
 they support up to 2GB file uploads. This threshold can be configured through
 the \code{pins.github.release} option which is specified in megabytes and
 defaults to \code{25}.
+
+When using GitHub Enterprise, consider customizing the \code{host} parameter to
+\code{"https://yourhostname/api/v3"}.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Attempt to support GitHub Enterprise by registering GitHub as:

```r
library(pins)
board_register_github(repo = "owner/repo", host = "https://yourhostname/api/v3")
```

GitHub Enterprise docs: https://developer.github.com/enterprise/2.17/v3/#authentication