### PR TITLE
Support concurrent pin() with shared cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Imports:
   openssl,
   rappdirs,
   withr,
-  xml2,
   yaml,
   zip
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
   yaml,
   zip
 Suggests:
+  callr,
   knitr,
   rmarkdown,
   R6,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.2.9002
+Version: 0.3.2.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))
@@ -20,6 +20,7 @@ Depends:
 Imports:
   base64enc,
   crayon,
+  filelock,
   httr,
   jsonlite,
   magrittr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 - Support for DigitalOcean board.
 
+## Pin
+
+- Support for using `pin()` across multiple concurrent processes (#182).
+
 ## RStudio
 
 - `pin()` now refreshes the connections pane.

--- a/R/board_local.R
+++ b/R/board_local.R
@@ -16,7 +16,7 @@ guess_extension_from_path <- function(path) {
 }
 
 board_pin_create.local <- function(board, path, name, metadata, ...) {
-  final_path <- pin_registry_update(name = name, component = board$name)
+  final_path <- pin_storage_path(component = board$name, name = name)
 
   unlink(final_path, recursive = TRUE)
   dir.create(final_path)

--- a/R/pin_registry.R
+++ b/R/pin_registry.R
@@ -3,12 +3,18 @@ pin_registry_config <- function(component) {
 }
 
 pin_registry_load_entries <- function(component) {
+  lock <- pin_registry_lock(component)
+  on.exit(pin_registry_unlock(lock))
+
   entries_path <- pin_registry_config(component)
 
   if (file.exists(entries_path)) yaml::read_yaml(entries_path, eval.expr = FALSE) else list()
 }
 
 pin_registry_save_entries <- function(entries, component) {
+  lock <- pin_registry_lock(component)
+  on.exit(pin_registry_unlock(lock))
+
   yaml::write_yaml(entries, pin_registry_config(component))
 }
 
@@ -20,8 +26,8 @@ pin_storage_path <- function(component, name) {
 }
 
 pin_registry_update <- function(name, component, params = list()) {
-  lock_file <- paste0(pin_registry_config(component), ".lock")
-  lock <- filelock::lock(lock_file, timeout = getOption("pins.lock.timeout", Inf))
+  lock <- pin_registry_lock(component)
+  on.exit(pin_registry_unlock(lock))
 
   entries <- pin_registry_load_entries(component)
   name <- pin_registry_qualify_name(name, entries)
@@ -50,11 +56,13 @@ pin_registry_update <- function(name, component, params = list()) {
 
   pin_registry_save_entries(entries, component)
 
-  filelock::unlock(lock)
   path
 }
 
 pin_registry_find <- function(text, component) {
+  lock <- pin_registry_lock(component)
+  on.exit(pin_registry_unlock(lock))
+
   entries <- pin_registry_load_entries(component)
 
   results <- pin_results_from_rows(entries)
@@ -67,6 +75,9 @@ pin_registry_find <- function(text, component) {
 }
 
 pin_registry_retrieve <- function(name, component) {
+  lock <- pin_registry_lock(component)
+  on.exit(pin_registry_unlock(lock))
+
   entries <- pin_registry_load_entries(component)
   name <- pin_registry_qualify_name(name, entries)
 
@@ -104,3 +115,13 @@ pin_registry_qualify_name <- function(name, entries) {
 
   name
 }
+
+pin_registry_lock <- function(component) {
+  lock_file <- paste0(pin_registry_config(component), ".lock")
+  filelock::lock(lock_file, timeout = getOption("pins.lock.timeout", Inf))
+}
+
+pin_registry_unlock <- function(lock) {
+  filelock::unlock(lock)
+}
+

--- a/R/pin_registry.R
+++ b/R/pin_registry.R
@@ -20,6 +20,9 @@ pin_storage_path <- function(component, name) {
 }
 
 pin_registry_update <- function(name, component, params = list()) {
+  lock_file <- paste0(pin_registry_config(component), ".lock")
+  lock <- filelock::lock(lock_file, timeout = getOption("pins.lock.timeout", Inf))
+
   entries <- pin_registry_load_entries(component)
   name <- pin_registry_qualify_name(name, entries)
 
@@ -47,6 +50,7 @@ pin_registry_update <- function(name, component, params = list()) {
 
   pin_registry_save_entries(entries, component)
 
+  filelock::unlock(lock)
   path
 }
 

--- a/tests/testthat/test-pin-object.R
+++ b/tests/testthat/test-pin-object.R
@@ -13,6 +13,7 @@ test_that("can pin() object", {
 test_that("can pin() concurrently", {
 
   temp_path <- tempfile()
+  if (dir.exists(temp_path)) unlink(temp_path, recursive = TRUE)
   dir.create(temp_path)
 
   processes <- list()
@@ -20,7 +21,7 @@ test_that("can pin() concurrently", {
     processes[[i]] <- callr::r_bg(function(temp_path) {
       options(pins.path = temp_path)
 
-      for (i in 1:100) {
+      for (i in 1:10) {
         pins::pin(list(message = "concurrent test"), name = basename(tempfile()))
       }
     }, args = list(temp_path), )
@@ -32,5 +33,5 @@ test_that("can pin() concurrently", {
 
   index <- yaml::read_yaml(file.path(temp_path, "local", "data.txt"))
 
-  expect_equal(length(index), 1000)
+  expect_equal(length(index), 100)
 })

--- a/tests/testthat/test-pin-object.R
+++ b/tests/testthat/test-pin-object.R
@@ -18,13 +18,13 @@ test_that("can pin() concurrently", {
 
   processes <- list()
   for (i in 1:10) {
-    processes[[i]] <- callr::r_bg(function(temp_path) {
+    processes[[i]] <- callr::r_bg(function(temp_path, proc) {
       options(pins.path = temp_path)
 
       for (i in 1:10) {
-        pins::pin(list(message = "concurrent test"), name = basename(tempfile()))
+        pins::pin(list(message = "concurrent test"), name = (proc * 100 + i), board = "local")
       }
-    }, args = list(temp_path), )
+    }, args = list(temp_path, i))
   }
 
   for (i in 1:10) {


### PR DESCRIPTION
Users have reported that in automated scripts the cache index can get corrupted.