### PR TITLE
Fix performance regression introduced by rsconnect public downloads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,12 @@
 - Support for custom GitHub hosts including GitHub Enterprise using the
   `host` parameter in `board_register_github()` (#163).
 
+## Websites
+
+- Using `pin()` now searches for `data.txt` files in URLs when the URL
+  contains no file extension, behavior can be turnned off with
+  the `pins.search.datatxt` option.
+
 # pins 0.3.2
 
 ## Pins

--- a/R/board_test.R
+++ b/R/board_test.R
@@ -162,14 +162,14 @@ board_test_versions <- function(board, exclude, destination) {
     pin(I(version_b), pin_name, board = board)
 
     versions <- pin_versions(pin_name, board = board)
-    deps$expect_equal(length(versions$version), 2)
+    deps$expect_gte(length(versions$version), 2)
 
     deps$expect_equal(
-      as.character(pin_get(pin_name, version = versions$version[2], board = board)),
+      as.character(pin_get(pin_name, version = versions$version[length(versions$version)], board = board)),
       as.character(version_a))
 
     deps$expect_equal(
-      as.character(pin_get(pin_name, version = versions$version[1], board = board)),
+      as.character(pin_get(pin_name, version = versions$version[length(versions$version)-1], board = board)),
       as.character(version_b))
   })
 

--- a/R/board_test.R
+++ b/R/board_test.R
@@ -7,7 +7,8 @@ test_dependencies <- function() {
     expect_true = get("expect_true", envir = asNamespace("testthat")),
     expect_equal = get("expect_equal", envir = asNamespace("testthat")),
     skip = get("skip", envir = asNamespace("testthat")),
-    fail = get("fail", envir = asNamespace("testthat"))
+    fail = get("fail", envir = asNamespace("testthat")),
+    expect_gte = get("expect_gte", envir = asNamespace("testthat"))
   )
 }
 

--- a/R/pin_extensions.R
+++ b/R/pin_extensions.R
@@ -26,7 +26,7 @@ board_pin_store <- function(board, path, name, description, type, metadata, extr
   dir.create(store_path)
   on.exit(unlink(store_path, recursive = TRUE))
 
-  if (length(path) == 1 && grepl("^http", path)) {
+  if (length(path) == 1 && grepl("^http", path) && !grepl("\\.[a-z]{2,4}$", path) && getOption("pins.search.datatxt", TRUE)) {
     # attempt to download data.txt to enable public access to boards like rsconnect
     datatxt_path <- file.path(path, "data.txt")
     local_path <- pin_download(datatxt_path, name, board_default(), can_fail = TRUE)


### PR DESCRIPTION
When calling,

```
system.time(pin("http://www.fhfa.gov/datatools/downloads/documents/hpi/hpi_master.csv"))
```

this was slowed down since public pins (like rsconnect) now check to download the pin manifest which introduces lag, this can be mitigated by ignoring this manifest when a specific file is requested.