### PR TITLE
allow setting of `access_type` for rsconnect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.3.2.9007
+Version: 0.3.2.9008
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# pins 0.3.2.9000
+# pins 0.3.2.9008
+
+- Support `access_type` parameter for RStudio Connect.
 
 - Support for DigitalOcean board.
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -45,7 +45,15 @@ board_initialize.rsconnect <- function(board, ...) {
   board
 }
 
-board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL, ...) {
+board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
+                                      ...) {
+  dots <- list(...)
+  access_type <- if (!is.null(access_type <- dots[["access_type"]])) {
+    match.arg(access_type, c("acl", "logged_in", "all"))
+  } else {
+    NULL
+  }
+
   deps <- rsconnect_dependencies()
 
   temp_dir <- file.path(tempfile(), name)
@@ -117,7 +125,8 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
                                       app_mode = "static",
                                       content_category = "pin",
                                       name = name,
-                                      description = board_metadata_to_text(metadata, metadata$description)
+                                      description = board_metadata_to_text(metadata, metadata$description),
+                                      access_type = access_type
                                     ))
 
       if (!is.null(content$error)) {


### PR DESCRIPTION
This change
- Allows the setting of access type of pins on RStudio Connect. Currently, users must log in to RStudio Connect and change access type through the GUI.

Tested manually with

```
library(pins)
board_register("rsconnect",
               server = "https://colorado.rstudio.com/rsc",
               key = Sys.getenv("CONNECT_API_KEY"))
pin(iris, "iris_private", board = "rsconnect")
pin(iris, "iris_public", board = "rsconnect", access_type = "all")
```