### PR TITLE
Update pin cache when etag is null

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pins 0.4.0.9000
+
+## Pin
+
+- Fix `pin()` failing to update cache when server returns `NULL` etag.
+
+
 # pins 0.4.0
 
 - Support for versioning in all boards.

--- a/R/pin_download.R
+++ b/R/pin_download.R
@@ -82,8 +82,10 @@ pin_download <- function(path,
       }
     }
 
+    etag_changed <- is.null(cache$etag) || !identical(old_cache$etag, cache$etag)
+
     # skip downloading if etag has not changed
-    if (old_cache_missing || !identical(old_cache$etag, cache$etag) || must_download) {
+    if (old_cache_missing || etag_changed || must_download) {
         download_name <- basename(path)
 
         if (remove_query) download_name <- strsplit(download_name, "\\?")[[1]][1]


### PR DESCRIPTION
The following code was not properly updating the cache due to server returning `NULL` etags:

```
usa <- readr::read_csv(pins::pin("http://covidtracking.com/api/states/daily.csv", name = "covid-usa"))
```