### PR TITLE
Add support for custom_metadata for advanced use cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0.9000
+Version: 0.4.0.9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fix `pin()` failing to update cache when server returns `NULL` etag.
 
+- Support for `custom_metadata` in `pin()` to allow saving custom fields
+  in `data.txt` file.
 
 # pins 0.4.0
 

--- a/R/pin.R
+++ b/R/pin.R
@@ -400,7 +400,7 @@ pin_info <- function(name,
 
   metadata <- list()
   if ("metadata" %in% colnames(entry) && nchar(entry$metadata) > 0) {
-    metadata <- jsonlite::fromJSON(entry$metadata)
+    metadata <- jsonlite::fromJSON(entry$metadata, simplifyDataFrame = FALSE)
   }
 
   if (signature) {

--- a/R/pin.R
+++ b/R/pin.R
@@ -420,45 +420,6 @@ pin_info <- function(name,
   structure(entry_ext, class = "pin_info")
 }
 
-print_pin_info <- function(name, e, ident) {
-  # avoid empty lavels that are nested
-  if (is.list(e) && is.null(names(e)) && length(e) == 1) e <- e[[1]]
-
-  # one-row data frames are better displayed as lists
-  if (is.data.frame(e) && nrow(e) == 1) e <- as.list(e)
-
-  name_prefix <- if (!is.null(name) && nchar(name) > 0) paste0(name, ": ") else ""
-
-  if (!is.list(e) && is.vector(e)) {
-    # Long strings (like paths) print better on their own line
-    if (length(e) > 1 && is.character(e) && max(nchar(e)) > 20) {
-      cat(crayon::silver(paste0("#", ident, "- ", name_prefix, "\n")))
-      for (i in e) {
-        print_pin_info("", i, paste0(ident, "  "))
-      }
-    }
-    else {
-      cat(crayon::silver(paste0("#", ident, "- ", name_prefix, paste(e, collapse = ", "), "\n")))
-    }
-  }
-  else if (is.data.frame(e)) {
-    cat(crayon::silver(paste0("#", ident, "- ", name_prefix)))
-    if (length(colnames(e)) > 0) cat(crayon::silver(paste0("(", colnames(e)[[1]], ") ")))
-    cat(crayon::silver(paste(e[,1], collapse = ", ")))
-    if (length(colnames(e)) > 1) cat(crayon::silver("..."))
-    cat(crayon::silver("\n"))
-  }
-  else if (is.list(e)) {
-    cat(crayon::silver(paste0("#", ident, "- ", name_prefix, "\n")))
-    for (i in names(e)) {
-      print_pin_info(i, e[[i]], paste0(ident, "  "))
-    }
-  }
-  else {
-    cat(crayon::silver(paste0("#", ident, "- ", name_prefix, class(e)[[1]], "\n")))
-  }
-}
-
 #' @keywords internal
 #' @export
 print.pin_info <- function(x, ...) {
@@ -470,15 +431,23 @@ print.pin_info <- function(x, ...) {
 
   info$board <- info$name <- info$type <- info$description <- info$signature <- NULL
 
-  is_first <- TRUE
-  for (name in names(info)) {
-    e <- info[[name]]
-    if (identical(is.na(e), FALSE) && identical(is.null(e), FALSE) && !(is.character(e) && nchar(e) == 0)) {
-      if (is_first) cat(crayon::silver(paste0("# Properties:", "\n")))
-      is_first <- FALSE
+  if (length(names(info)) > 0) {
+    cat(crayon::silver(paste0("# Properties:", "\n")))
 
-      print_pin_info(name, e, "   ")
+    for (i in names(info)) {
+      entry <- info[[i]]
+      if ((is.list(entry) && length(entry) == 0) ||
+          (is.character(entry) && identical(nchar(entry), 0L)) ||
+          identical(i, "path")) {
+        info[[i]] <- NULL
+      }
     }
+
+    yaml_str <- yaml::as.yaml(info) %>%
+      strsplit("\n") %>%
+      sapply(function(e) paste("#  ", e)) %>%
+      paste0(collapse = "\n")
+    cat(crayon::silver(yaml_str))
   }
 }
 

--- a/R/pin_extensions.R
+++ b/R/pin_extensions.R
@@ -7,14 +7,14 @@
 #' @param path The path to store.
 #' @param description The text patteren to find a pin.
 #' @param type The type of pin being stored.
-#' @param metadata A list containing additional metadata desecribing the pin.
+#' @param metadata A list containing additional metadata describing the pin.
 #' @param ... Additional parameteres.
 #'
 #' @rdname custom-pins
 #'
 #' @export
 #' @rdname custom-pins
-board_pin_store <- function(board, path, name, description, type, metadata, extract = TRUE, ...) {
+board_pin_store <- function(board, path, name, description, type, metadata, extract = TRUE, custom_metadata = NULL, ...) {
   board <- board_get(board)
   if (is.null(name)) name <- gsub("[^a-zA-Z0-9]+", "_", tools::file_path_sans_ext(basename(path)))[[1]]
   pin_log("Storing ", name, " into board ", board$name, " with type ", type)
@@ -58,6 +58,8 @@ board_pin_store <- function(board, path, name, description, type, metadata, extr
   if (!pin_manifest_exists(store_path)) {
     metadata$description <- description
     metadata$type <- type
+
+    metadata <- pins_merge_custom_metadata(metadata, custom_metadata)
 
     pin_manifest_create(store_path, metadata, dir(store_path, recursive = TRUE))
   }

--- a/R/pins_metadata.R
+++ b/R/pins_metadata.R
@@ -1,0 +1,34 @@
+pins_merge_custom_metadata <- function(metadata, custom_metadata) {
+  fixed_fields <- c("rows",
+                    "cols",
+                    "name",
+                    "description")
+
+  for (entry in names(custom_metadata)) {
+    if (identical(entry, "columns")) {
+      fixed_columnn_fields <- c("name", "type")
+
+      # convert to list of columns
+      if (is.vector(metadata$columns)) {
+        metadata$columns <- lapply(seq_along(metadata$columns), function(e) list(name = names(metadata$columns)[[e]], type = metadata$columns[[e]]))
+      }
+
+      for (column in custom_metadata$columns) {
+        found_idx <- Filter(function(e) identical(metadata$columns[[e]]$name, column$name), seq_along(metadata$columns))
+
+        if (identical(length(found_idx), 1L)) {
+          for (field_name in names(column)) {
+            if (!field_name %in% fixed_columnn_fields) {
+              metadata$columns[[found_idx]][[field_name]] <- column[[field_name]]
+            }
+          }
+        }
+      }
+    }
+    else if (!entry %in% fixed_fields) {
+      metadata[[entry]] <- custom_metadata[[entry]]
+    }
+  }
+
+  metadata
+}

--- a/R/pins_metadata.R
+++ b/R/pins_metadata.R
@@ -13,6 +13,11 @@ pins_merge_custom_metadata <- function(metadata, custom_metadata) {
         metadata$columns <- lapply(seq_along(metadata$columns), function(e) list(name = names(metadata$columns)[[e]], type = metadata$columns[[e]]))
       }
 
+      if (is.data.frame(custom_metadata$columns)) {
+        custom_metadata$columns <- custom_metadata$columns %>%
+          jsonlite::toJSON() %>% jsonlite::fromJSON(simplifyDataFrame = FALSE)
+      }
+
       for (column in custom_metadata$columns) {
         found_idx <- Filter(function(e) identical(metadata$columns[[e]]$name, column$name), seq_along(metadata$columns))
 

--- a/R/ui_viewer.R
+++ b/R/ui_viewer.R
@@ -87,8 +87,14 @@ ui_viewer_register <- function(board, board_call) {
       if (!is.null(pin_index$metadata) || nchar(pin_index$metadata) > 0) {
         metadata <- jsonlite::fromJSON(pin_index$metadata)
         if (!is.null(metadata$columns)) {
-          attr_names <- c(attr_names, names(metadata$columns))
-          attr_values <- c(attr_values, as.character(metadata$columns))
+          if (is.vector(metadata$columns)) {
+            attr_names <- c(attr_names, names(metadata$columns))
+            attr_values <- c(attr_values, as.character(metadata$columns))
+          }
+          else {
+            attr_names <- metadata$columns$name
+            attr_values <- metadata$columns$type
+          }
         }
 
         if (identical(metadata$type, "files") && length(attr_names) == 0) {

--- a/tests/testthat/test-pin-metadata.R
+++ b/tests/testthat/test-pin-metadata.R
@@ -16,7 +16,8 @@ test_that("can pin() with custom metadata", {
 
   info <- pin_info("iris-metadata", board = "local")
 
-  expect_equal(names(info$columns), c("name", "type", "description"))
+  expect_equal(length(info$columns), 5L)
+  expect_equal(names(info$columns[[1]]), c("name", "type", "description"))
   expect_equal(info$source, "The R programming language")
 })
 

--- a/tests/testthat/test-pins-metadata.R
+++ b/tests/testthat/test-pins-metadata.R
@@ -1,0 +1,22 @@
+context("pin metadata")
+
+test_that("can pin() with custom metadata", {
+  skip_on_cran()
+
+  pin(iris, "iris-metadata", custom_metadata = list(
+    source = "The R programming language",
+    columns = list(
+      list(name = "Species", description = "Really like this column"),
+      list(name = "Sepal.Length", description = "Sepal Length"),
+      list(name = "Sepal.Width", description = "Sepal Width"),
+      list(name = "Petal.Length", description = "Petal Length"),
+      list(name = "Petal.Width", description = "Petal Width"))
+    )
+  )
+
+  info <- pin_info("iris-metadata", board = "local")
+
+  expect_equal(names(info$columns), c("name", "type", "description"))
+  expect_equal(info$source, "The R programming language")
+})
+


### PR DESCRIPTION
Support for,

```r
pin(iris, "iris-metadata", custom_metadata = list(
    source = "The R programming language",
    columns = list(
      list(name = "Species", description = "Really like this column"),
      list(name = "Sepal.Length", description = "Sepal Length"),
      list(name = "Sepal.Width", description = "Sepal Width"),
      list(name = "Petal.Length", description = "Petal Length"),
      list(name = "Petal.Width", description = "Petal Width"))
    )
)

pin_info("iris-metadata", board = "local", metadata = TRUE, extended = TRUE) %>%
    yaml::as.yaml() %>%
    cat()
```
```
name: iris-metadata
description: ''
type: table
path:
- iris-metadata/data.csv
- iris-metadata/data.rds
rows: 150
cols: 5
source: The R programming language
columns:
- name: Sepal.Length
  type: numeric
  description: Sepal Length
- name: Sepal.Width
  type: numeric
  description: Sepal Width
- name: Petal.Length
  type: numeric
  description: Petal Length
- name: Petal.Width
  type: numeric
  description: Petal Width
- name: Species
  type: factor
  description: Really like this column
board: local
```