### PR TITLE
Disable caches when running inside RStudio Connect and other prod environments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0.9001
+Version: 0.4.0.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,17 @@
 
 ## Pin
 
+- When running in production environments (which usually set the `R_CONFIG_ACTIVE`
+  environment variable), avoid using shared caches.
+
 - Fix `pin()` failing to update cache when server returns `NULL` etag.
 
 - Support for `custom_metadata` in `pin()` to allow saving custom fields
   in `data.txt` file.
+  
+- RStudio Connect
+
+- Avoid using shared caches when running inside RStudio Connect.
 
 # pins 0.4.0
 

--- a/R/board_registration.R
+++ b/R/board_registration.R
@@ -9,7 +9,11 @@
 #' board_cache_path()
 #' @export
 board_cache_path <- function() {
-  getOption("pins.path", rappdirs::user_cache_dir("pins"))
+  # if a configuration is present this could mean we are running in a production environment without user caches
+  if (nchar(Sys.getenv("R_CONFIG_ACTIVE")) > 0 && nchar(Sys.getenv("PINS_USE_CACHE")) == 0)
+    tempfile()
+  else
+    getOption("pins.path", rappdirs::user_cache_dir("pins"))
 }
 
 #' Register Local Board


### PR DESCRIPTION
Production environments usually set the `R_CONFIG_ACTIVE` environment variable by using the `config` package. Avoid using caches in those environments unless requested explicitly by setting a `PINS_USE_CACHE` environment variable.