### PR TITLE
Support recreating pin with corrupt metadata in RStudio Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0.9002
+Version: 0.4.0.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,9 @@
 - Support for `custom_metadata` in `pin()` to allow saving custom fields
   in `data.txt` file.
   
-- RStudio Connect
+## RStudio Connect
+
+- Fix when overriding pin with corrupt metadata.
 
 - Avoid using shared caches when running inside RStudio Connect.
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -235,10 +235,9 @@ board_pin_find.rsconnect <- function(board,
     remote_path <- rsconnect_remote_path_from_url(board, entries[[1]]$url)
     etag <- as.character(entries[[1]]$last_deployed_time)
 
-    local_path <- rsconnect_api_download(board, entries[[1]]$name, file.path(remote_path, "data.txt"), etag = etag)
-
     manifest <- list()
     if (identical(metadata, TRUE)) {
+      local_path <- rsconnect_api_download(board, entries[[1]]$name, file.path(remote_path, "data.txt"), etag = etag)
       manifest <- pin_manifest_get(local_path)
     }
 


### PR DESCRIPTION
If uploads fail in RStudio Connect, it can be possible to end up with a pin with missing `data.txt` metadata. This fix allows re-uploading the pin in such case.