### PR TITLE
Improve performance for pin() when cache exist for URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0.9004
+Version: 0.4.0.9005
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 - Support for `custom_metadata` in `pin()` to allow saving custom fields
   in `data.txt` file.
   
+- Improve performannce for `pin()` from URLs containing large files that are
+  already been cached prerviously by `pin()` (#225).
+  
 ## RStudio Connect
 
 - Fix when overriding pin with corrupt metadata.

--- a/R/pin_download.R
+++ b/R/pin_download.R
@@ -10,6 +10,7 @@ pin_download_one <- function(path,
                              cache = TRUE,
                              content_length = 0,
                              subpath = name,
+                             details = new.env(),
                              ...) {
   must_download <- !cache
 
@@ -61,6 +62,7 @@ pin_download_one <- function(path,
   extract_type <- NULL
 
   pin_log("Checking 'change_age' header (time, change age, max age): ", as.numeric(Sys.time()), ", ", cache$change_age, ", ", cache$max_age)
+  details$something_changed <- FALSE
 
   # skip downloading if max-age still valid
   if (as.numeric(Sys.time()) >= cache$change_age + cache$max_age || must_download) {
@@ -93,6 +95,7 @@ pin_download_one <- function(path,
         if (remove_query) download_name <- strsplit(download_name, "\\?")[[1]][1]
         destination_path <- file.path(temp_path, download_name)
         pin_log("Downloading ", path, " to ", destination_path)
+        details$something_changed <- TRUE
 
         write_spec <- httr::write_disk(destination_path, overwrite = TRUE)
         result <- catch_error(httr::GET(path, write_spec, headers, config, http_utils_progress(size = content_length)))


### PR DESCRIPTION
For large remote files already cached, while the file is not re-downloaded, it is copied from the temp folder back to the local storage causing a significant delay:

```r
devtools::install_github("rstudio/pins")

# precache tiny imagenet
tiny_imagenet <- pins::pin("http://cs231n.stanford.edu/tiny-imagenet-200.zip")

system.time({ tiny_imagenet <- pins::pin("http://cs231n.stanford.edu/tiny-imagenet-200.zip") })
```
```
   user  system elapsed 
 10.353 102.528 165.082
```

This fix avoid copying anything to the temp folder if the pin is already cached:

```r
devtools::install_github("rstudio/pins", ref = "bugfix/pin-cache-perf")

system.time({ tiny_imagenet <- pins::pin("http://cs231n.stanford.edu/tiny-imagenet-200.zip") })
```
```
   user  system elapsed 
  6.983   0.889   5.622
```

Note: tiny imagenet is about 250MB, smaller files might not see a considerable improvement.