### PR TITLE
Avoid progress on non-interactive sessions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.0.9005
+Version: 0.4.0.9006
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 - Improve performannce for `pin()` from URLs containing large files that are
   already been cached prerviously by `pin()` (#225).
   
+- Avoid showing upload or download progress when creating R Markdown documents
+  and other non-interactive use cases (#227).
+  
 ## RStudio Connect
 
 - Fix when overriding pin with corrupt metadata.

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,7 +11,7 @@ pins_show_progress <- function(size = 0) {
   if (is.character(size)) size <- as.integer(size)
 
   large_file <- getOption("pins.progress.size", 10^7)
-  identical(getOption("pins.progress", size > large_file), TRUE)
+  identical(getOption("pins.progress", size > large_file), TRUE) && interactive()
 }
 
 pins_save_csv <- function(x, name) {


### PR DESCRIPTION
When knitting documents one gets for large files:

<img width="1037" alt="Screen Shot 2020-05-18 at 1 10 43 PM" src="https://user-images.githubusercontent.com/3478847/82255154-05d7b700-9909-11ea-983d-1cb7609f9ee4.png">

This PR disables progress in non-interactive sessions.