### PR TITLE
Properly construct the url when remove cloud pins to fix #234

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# pins 0.4.1.9000
+
+## Website
+
+- Fix issue removing pins with custom domain names from cloud boards (#234).
+
 # pins 0.4.1
 
 ## Pin

--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -213,10 +213,13 @@ datatxt_response_content <- function(response) {
 
 datatxt_update_index <- function(board, path, operation, name = NULL, metadata = NULL) {
   index_url <- file.path(board$url, "data.txt")
-  response <- httr::GET(index_url, board_datatxt_headers(board, index_url))
+  response <- httr::GET(index_url, board_datatxt_headers(board, "data.txt"))
 
   index <- list()
-  if (!httr::http_error(response)) {
+  if (httr::http_error(response)) {
+    stop("Failed to retrieve latest data.txt file, the pin was partially removed.")
+  }
+  else {
     content <- datatxt_response_content(response)
 
     index <- board_manifest_load(content)


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/234