### PR TITLE
Support for custom domains in datatxt boards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.1.9000
+Version: 0.4.1.9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Fix issue removing pins with custom domain names from cloud boards (#234).
 
+- Fix warning when using `pin()` against storage locations with custom domain name (#237).
+
 # pins 0.4.1
 
 ## Pin

--- a/R/board_datatxt_headers.R
+++ b/R/board_datatxt_headers.R
@@ -1,4 +1,9 @@
 board_datatxt_headers <- function(board, path, verb = "GET", file = NULL) {
+  if (!is.null(board$url)) {
+    # remove base url form path since S3 and others require relative paths when using custom domains
+    path <- gsub(paste0("^", board$url, "/?"), "", path)
+  }
+
   if (is.list(board$headers)) {
     httr::add_headers(.headers = unlist(board$headers))
   }


### PR DESCRIPTION
Fix for `pin()` throwing warning and inconsistent cache state when using custom domain names with `datatxt` boards.