### PR TITLE
Always sync to most up to date datatxt index to fix #239

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.1.9001
+Version: 0.4.1.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Fix warning when using `pin()` against storage locations with custom domain name (#237).
 
+- Fix issue where datatxt was not refreshing deleted entries (#239).
+
 # pins 0.4.1
 
 ## Pin

--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -17,13 +17,7 @@ datatxt_refresh_index <- function(board) {
     }
   }
   else {
-    new_index <- board_manifest_get(temp_index)
-    current_names <- sapply(current_index, function(e) e$name)
-    for (new_entry in new_index) {
-      if (!new_entry$name %in% current_names) {
-        current_index[[length(current_index) + 1]] <- new_entry
-      }
-    }
+    current_index <- board_manifest_get(temp_index)
   }
 
   yaml::write_yaml(current_index, local_index)


### PR DESCRIPTION
Reprex here is to create an S3 board, then change the local datatxt with records that don't exist in the remote datatxt, to find out the index is not properly updated.