### PR TITLE
Support to disable versions in RStudio Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.1.9002
+Version: 0.4.1.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,11 @@
 
 - Fix issue where datatxt was not refreshing deleted entries (#239).
 
+## RStudio Connect
+
+- Support for `versions = FALSE` in `board_register()` to avoid using too much space when
+  creating pins (#245).
+
 # pins 0.4.1
 
 ## Pin

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -99,10 +99,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
     deps$output_metadata$set(rsc_output_files = file.path(knit_pin_dir, dir(knit_pin_dir, recursive = TRUE)))
   }
   else {
-    # when versioning is turned off we also need to clean up previous bundles so we store the current versions
-    if (!board_versions_enabled(board)) {
-      previous_versions <- board_pin_versions(board, name)
-    }
+    previous_versions <- NULL
 
     existing <- rsconnect_get_by_name(board, name)
     if (nrow(existing) == 0) {
@@ -123,6 +120,11 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
     }
     else {
       guid <- existing$guid
+
+      # when versioning is turned off we also need to clean up previous bundles so we store the current versions
+      if (!board_versions_enabled(board)) {
+        previous_versions <- board_pin_versions(board, name)
+      }
 
       content <- rsconnect_api_post(board,
                                     paste0("/__api__/v1/experimental/content/", guid),
@@ -191,7 +193,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
     result <- rsconnect_wait_by_name(board, name)
 
     # when versioning is turned off we also need to clean up previous bundles
-    if (!board_versions_enabled(board)) {
+    if (!board_versions_enabled(board) && !is.null(previous_versions)) {
       for (idx in 1:nrow(previous_versions)) {
         delete_version <- previous_versions[idx,]
 

--- a/R/board_rsconnect_api.R
+++ b/R/board_rsconnect_api.R
@@ -40,9 +40,14 @@ rsconnect_api_get <- function(board, path) {
 }
 
 rsconnect_api_delete <- function(board, path) {
-  httr::DELETE(paste0(board$server, path),
-               rsconnect_api_auth_headers(board, path, "DELETE")) %>%
-    httr::content()
+  result <- httr::DELETE(paste0(board$server, path),
+               rsconnect_api_auth_headers(board, path, "DELETE"))
+
+  if (httr::http_error(result)) {
+    stop("Failed to delete ", path, " ", as.character(httr::content(result)))
+  }
+
+  result %>% httr::content()
 }
 
 rsconnect_api_post <- function(board, path, content, encode, progress = NULL) {

--- a/vignettes/use-cases.Rmd
+++ b/vignettes/use-cases.Rmd
@@ -1,5 +1,10 @@
 ---
 title: "Use Cases"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Using Website Boards}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\usepackage[utf8]{inputenc}
 ---
 
 ```{r setup, include=FALSE}


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/245, enables:

```r
library(pins)
board_register(board = "rsconnect", versions = FALSE)
pin(iris, "iris-versioned", board = "rsconnect")
pin_versions("iris-versioned", board = "rsconnect")
```
```
# A tibble: 1 x 3
  version created               size
  <chr>   <chr>                <int>
1 8671    2020-06-15T23:38:15Z 23760
```

Notice that creating a new pin does not create a new version:

```r
pin(iris, "iris-versioned", board = "rsconnect")
pin_versions("iris-versioned", board = "rsconnect")
```
```
# A tibble: 1 x 3
  version created               size
  <chr>   <chr>                <int>
1 8672    2020-06-15T23:38:51Z 23750
```