### PR TITLE
Avoid overriding pin by admins in rsconnect boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
   include:
     - name: "R"
       r: 3.2.3
-      r_check_args: "--no-build-vignettes --no-vignettes"
       warnings_are_errors: true
-      r_github_packages:
-        - RcppCore/Rcpp
       script:
         - gcloud version || true
         - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
@@ -33,8 +30,8 @@ matrix:
         - base64 --decode gcloud.b64 > gcloud.json
         - gcloud auth activate-service-account --key-file gcloud.json
         - |
-          R CMD build --resave-data .
-          R CMD check --no-build-vignettes --no-manual --no-tests pins*tar.gz
+          R CMD build --resave-data --no-build-vignettes --no-vignettes .
+          R CMD check --no-manual --ignore-vignettes --no-vignettes --no-tests pins*tar.gz
           Rscript ci/travis.R
       env:
         -TEST_GITHUB_BRANCH="travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   include:
     - name: "R"
       r: 3.2.3
+      r_check_args: "--no-build-vignettes --ignore-vignettes"
       warnings_are_errors: true
       r_github_packages:
         - RcppCore/Rcpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ matrix:
         - base64 --decode gcloud.b64 > gcloud.json
         - gcloud auth activate-service-account --key-file gcloud.json
         - |
-          R CMD build --resave-data --no-build-vignettes --no-vignettes .
-          R CMD check --no-manual --ignore-vignettes --no-vignettes --no-tests pins*tar.gz
+          R CMD build --resave-data --no-build-vignettes .
+          R CMD check --no-manual --ignore-vignettes --no-tests pins*tar.gz
           Rscript ci/travis.R
       env:
         -TEST_GITHUB_BRANCH="travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   include:
     - name: "R"
       r: 3.2.3
-      r_check_args: "--no-build-vignettes --ignore-vignettes"
+      r_check_args: "--no-build-vignettes --no-vignettes"
       warnings_are_errors: true
       r_github_packages:
         - RcppCore/Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.1.9003
+Version: 0.4.1.9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - Support for `versions = FALSE` in `board_register()` to avoid using too much space when
   creating pins (#245).
+  
+- Prevent administrators from overriding pins they don't own (#253).
 
 # pins 0.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,8 @@
 - Support for `versions = FALSE` in `board_register()` to avoid using too much space when
   creating pins (#245).
   
-- Prevent administrators from overriding pins they don't own (#253).
+- Prevent administrators from overriding pins they don't own, unless the pin is specified 
+  as `user/name` (#253).
 
 # pins 0.4.1
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -25,6 +25,7 @@ board_initialize.rsconnect <- function(board, ...) {
     board$server <-  gsub("/$", "", args$server)
     board$server_name <- gsub("https?://|(:[0-9]+)?/.*", "", args$server)
   }
+
   board$account <- args$account
   board$output_files <- args$output_files
 
@@ -41,6 +42,10 @@ board_initialize.rsconnect <- function(board, ...) {
   }
 
   board$pins_supported <- tryCatch(rsconnect_pins_supported(board), error = function(e) FALSE)
+
+  if (is.null(board$account )) {
+    board$account  <- rsconnect_api_get(board, "/__api__/users/current/")$username
+  }
 
   board
 }
@@ -63,14 +68,12 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
   x <- if (identical(dir(path, "data\\.rds"), "data.rds"))
     readRDS(dir(path, "data\\.rds", full.names = TRUE)) else path
 
+  if (grepl("/", name)) stop("You can only pin() to your own '", board$account, "' account.")
+  name_qualified <- paste0(board$account, "/", name)
+
   account_name <- board$account
   if (identical(board$output_files, TRUE)) {
     account_name <- "https://rstudio-connect-server/content/app-id"
-  }
-  else {
-    if (is.null(account_name)) {
-      account_name <- rsconnect_api_get(board, "/__api__/users/current/")$username
-    }
   }
 
   file.copy(dir(path, full.names = TRUE), temp_dir)
@@ -101,7 +104,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
   else {
     previous_versions <- NULL
 
-    existing <- rsconnect_get_by_name(board, name)
+    existing <- rsconnect_get_by_name(board, name_qualified)
     if (nrow(existing) == 0) {
       content <- rsconnect_api_post(board,
                                   paste0("/__api__/v1/experimental/content"),
@@ -190,7 +193,7 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
     }
 
     # it might take a few seconds for the pin to register in rsc, see travis failures, wait 5s
-    result <- rsconnect_wait_by_name(board, name)
+    result <- rsconnect_wait_by_name(board, name_qualified)
 
     # when versioning is turned off we also need to clean up previous bundles
     if (!board_versions_enabled(board) && !is.null(previous_versions)) {

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -68,8 +68,13 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
   x <- if (identical(dir(path, "data\\.rds"), "data.rds"))
     readRDS(dir(path, "data\\.rds", full.names = TRUE)) else path
 
-  if (grepl("/", name)) stop("You can only pin() to your own '", board$account, "' account.")
-  name_qualified <- paste0(board$account, "/", name)
+  if (grepl("/", name)) {
+    name_qualified <- name
+    name <- gsub(".*/", "", name_qualified)
+  }
+  else {
+    name_qualified <- paste0(board$account, "/", name)
+  }
 
   account_name <- board$account
   if (identical(board$output_files, TRUE)) {


### PR DESCRIPTION
Admins can override other user content in RStudio Connect boards. This is fine, but `pin()` was defaulting to overriding whichever pin was found by the user. Now we default to the qualified name `user/name` to avoid overriding something unintentionally.

Still, it might be a useful use case for one user to contribute to other user's pin if and only if, the user has permissions to modify such content.