### PR TITLE
Support RStudio Connect servers with mismatched protocols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.3.9004
+Version: 0.4.3.9005
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@
 
 - Support for `pin_get(download = FALSE)` to avoid checking for updates.
 
+## RStudio Connect
+
+- Support for servers with mismatched `http` vs `https` protocols.
+
 # pins 0.4.3
 
 ## Boards

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -315,7 +315,10 @@ rsconnect_wait_by_name <- function(board, name) {
 }
 
 rsconnect_remote_path_from_url <- function(board, url) {
-  url <- gsub(paste0("^.*", board$server), "", url)
+  url <- gsub("^https?://", "", url)
+  server <- gsub("^https?://", "", board$server)
+
+  url <- gsub(paste0("^.*", server), "", url)
   gsub("/$", "", url)
 }
 

--- a/tests/testthat/test-board-rsconnect.R
+++ b/tests/testthat/test-board-rsconnect.R
@@ -62,6 +62,12 @@ test_that("User-supplied html files can overwrite the default", {
   expect_equal(readLines(file.path(dir, "index.html")), "new_file")
 })
 
+test_that("Mismatched protocols generate correct URL", {
+  path <- rsconnect_remote_path_from_url(list(server = "https://foo.com/rsc"), "http://foo.com/rsc/foo/bar")
+  expect_equal(path, "/foo/bar")
 
+  path <- rsconnect_remote_path_from_url(list(server = "http://foo.com/rsc"), "https://foo.com/rsc/foo/bar")
+  expect_equal(path, "/foo/bar")
+})
 
 


### PR DESCRIPTION
Some RStudio Connect servers might be registered to use `http`, but enforce `https`. While this configuration might not be ideal, this fix enables board URLs to handle mismatched protocols.