### PR TITLE
In the wild variation of capitalization

### DIFF
--- a/tools/process-cran.R
+++ b/tools/process-cran.R
@@ -22,7 +22,7 @@ cran_process_file <- function(package_path, file_path) {
   dataset_title <- NULL
   file_name <- basename(file_path)
   dataset_name <- tools::file_path_sans_ext(file_name)
-  if (tools::file_ext(file_name) %in% c("rda", "RData")) {
+  if (tolower(tools::file_ext(file_name)) %in% c("rda", "rdata")) {
     doc_file <- file.path(package_path, "man", paste0(dataset_name, ".Rd"))
     if (file.exists(doc_file)) {
       dataset_doc <- tools::parse_Rd(doc_file)


### PR DESCRIPTION
Significant variation on CRAN for Rdata, rData, rdata. Rda, RDA, rda, etc. The current only captures one variation. Enforcing tolower on extension so that the cranfiles generation script can see these. 

Example: #216 