### PR TITLE
update vignette for extending boards for using in new R package

### DIFF
--- a/vignettes/boards-extending.Rmd
+++ b/vignettes/boards-extending.Rmd
@@ -62,7 +62,7 @@ board_pin_remove.folder <- function(board, name, ...) {
 }
 ```
 
-If we want to provide the above methods in a separate package, this new package also needs to export the s3 generics from `pins`. For example:
+To extend `pins` in a separate package, make sure to export the s3 generics from `pins`. For example:
 
 ```{r eval=FALSE}
 #' @importFrom pins board_initialize
@@ -85,4 +85,3 @@ pins::board_pin_find
 #' @export
 pins::board_pin_remove
 ```
-

--- a/vignettes/boards-extending.Rmd
+++ b/vignettes/boards-extending.Rmd
@@ -61,3 +61,28 @@ board_pin_remove.folder <- function(board, name, ...) {
   unlink(file.path("pins", name), recursive = TRUE)
 }
 ```
+
+If we want to provide the above methods in a separate package, this new package also needs to export the s3 generics from `pins`. For example:
+
+```{r eval=FALSE}
+#' @importFrom pins board_initialize
+#' @export
+pins::board_initialize
+
+#' @importFrom pins board_pin_create
+#' @export
+pins::board_pin_create
+
+#' @importFrom pins board_pin_get
+#' @export
+pins::board_pin_get
+
+#' @importFrom pins board_pin_find
+#' @export
+pins::board_pin_find
+
+#' @importFrom pins board_pin_remove
+#' @export
+pins::board_pin_remove
+```
+


### PR DESCRIPTION
Thanks for the great package!

we recently ran into a minor block when trying to implement new board methods and provide those in a new package: the new methods work as a standalone R script but not in the package, because we didn't export the generics in the new package. Although this is a general issue about extending existing s3 methods provided in another package, I thought it would save other people some time if it's in the vignette, so I added a section on exporting s3 generics from pins when new board methods through a new package.