### PR TITLE
Show proper errors for invalid account and server in rsconnect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4
+Version: 0.4.4.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# pins 0.4.4.9000
+
+## RStudio Connect
+
+- Invalid 'account' or 'server' parameters show proper errors (#296).
+
 # pins 0.4.4
 
 ## Pins

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -43,7 +43,7 @@ board_initialize.rsconnect <- function(board, ...) {
 
   board$pins_supported <- tryCatch(rsconnect_pins_supported(board), error = function(e) FALSE)
 
-  if (is.null(board$account )) {
+  if (is.null(board$account)) {
     board$account  <- rsconnect_api_get(board, "/__api__/users/current/")$username
   }
 

--- a/R/board_rsconnect_token.R
+++ b/R/board_rsconnect_token.R
@@ -39,10 +39,18 @@ rsconnect_token_initialize <- function(board) {
     board$server_name <- accounts$server[1]
   }
 
+  if (!any(accounts$server == board$server_name)) {
+    stop("The server ", board$server_name, " is not registered, available servers: ", paste0(accounts$server, collapse = ", "))
+  }
+
   if (is.null(board$account)) board$account <- accounts[accounts$server == board$server_name,]$name
 
   if (length(board$account) != 1) {
     stop("Multiple accounts (", paste(board$account, collapse = ", "), ") are associated to this server, please specify the correct account parameter in board_register().")
+  }
+
+  if (!any(accounts$name == board$account)) {
+    stop("The account ", board$account, " is not registered, available accounts: ", paste0(accounts$name, collapse = ", "))
   }
 
   # always use the url from rstudio to ensure redirects work properly even when the full path is not specified

--- a/R/board_rsconnect_token.R
+++ b/R/board_rsconnect_token.R
@@ -40,7 +40,8 @@ rsconnect_token_initialize <- function(board) {
   }
 
   if (!any(accounts$server == board$server_name)) {
-    stop("The server ", board$server_name, " is not registered, available servers: ", paste0(accounts$server, collapse = ", "))
+    registered <- accounts$server[!grepl("^shinyapps.io", accounts$server)]
+    stop("The server ", board$server_name, " is not registered, available servers: ", paste0(registered, collapse = ", "))
   }
 
   if (is.null(board$account)) board$account <- accounts[accounts$server == board$server_name,]$name


### PR DESCRIPTION
When an invalid `account` or `server` parameter are specified in `rsconnect` boards, the following errors are thrown:

```
The server foo is not registered, available servers: beta.rstudioconnect.com 
```

and

```
The account jluraschi is not registered, available accounts: jluraschi, javier
```