### PR TITLE
Increase entries retrieved in pin_find() for rsconnect to fix #297

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9000
+Version: 0.4.4.9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 - Invalid 'account' or 'server' parameters show proper errors (#296).
 
+- Increase total entries retrieved with `pin_find()`, configurable with
+  `pins.search.count` (#296).
+
 # pins 0.4.4
 
 ## Pins

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -230,7 +230,7 @@ board_pin_find.rsconnect <- function(board,
 
   if (identical(board$pins_supported, TRUE)) content_filter <- "filter=content_type:pin&"
 
-  entries <- rsconnect_api_get(board, paste0("/__api__/applications/?", content_filter, utils::URLencode(filter)))$applications
+  entries <- rsconnect_api_get(board, paste0("/__api__/applications/?count=", getOption("pins.search.count", 10000) ,"&", content_filter, utils::URLencode(filter)))$applications
   if (!all_content) entries <- Filter(function(e) e$content_category == "pin", entries)
 
   entries <- lapply(entries, function(e) { e$name <- paste(e$owner_username, e$name, sep = "/") ; e })


### PR DESCRIPTION
Increase entries retrieved from,

```
> pin_find("", board = "rsconnect")
# A tibble: 40 x 4
   name                        description                       type  board    
   <chr>                       <chr>                             <chr> <chr>    
 1 amanda/ticket_attachments   ""                                table rsconnect
 2 javier_personal/iris-public ""                                table rsconnect
 3 javier_personal/iris-shared ""                                table rsconnect
 4 jluraschi/afile11           "A files pin with txt extension." files rsconnect
 5 jluraschi/afile141          "A files pin with txt extension." files rsconnect
 6 jluraschi/afile144          "A files pin with txt extension." files rsconnect
 7 jluraschi/afile164          "A files pin with txt extension." files rsconnect
 8 jluraschi/afile227          "A files pin with txt extension." files rsconnect
 9 jluraschi/afile240          "A files pin with txt extension." files rsconnect
10 jluraschi/afile283          "A files pin with txt extension." files rsconnect
# … with 10 more rows
```

to,

```
> pin_find("", board = "rsconnect")
# A tibble: 40 x 4
   name                        description                       type  board    
   <chr>                       <chr>                             <chr> <chr>    
 1 amanda/ticket_attachments   ""                                table rsconnect
 2 javier_personal/iris-public ""                                table rsconnect
 3 javier_personal/iris-shared ""                                table rsconnect
 4 jluraschi/afile11           "A files pin with txt extension." files rsconnect
 5 jluraschi/afile141          "A files pin with txt extension." files rsconnect
 6 jluraschi/afile144          "A files pin with txt extension." files rsconnect
 7 jluraschi/afile164          "A files pin with txt extension." files rsconnect
 8 jluraschi/afile227          "A files pin with txt extension." files rsconnect
 9 jluraschi/afile240          "A files pin with txt extension." files rsconnect
10 jluraschi/afile283          "A files pin with txt extension." files rsconnect
# … with 30 more rows
```

With this change, `pins` request `10000` by default; but this parameter is configurable with a new `pins.search.count` option.