### PR TITLE
Fix regression introduced in #253 to re-enable collaboration and fix #302

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9001
+Version: 0.4.4.9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 - Increase total entries retrieved with `pin_find()`, configurable with
   `pins.search.count` (#296).
+  
+- Fix regression introduced in pins 0.4.2 (#253) preventing users from
+  collaborating on existing pins they have access to (#302).
 
 # pins 0.4.4
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -71,12 +71,16 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
   if (grepl("/", name)) {
     name_qualified <- name
     name <- gsub(".*/", "", name_qualified)
+    account_name <- gsub("/.*", "", name_qualified)
+
+    if (grepl("/", name) || grepl("/", account_name))
+      stop("Pin names must follow the user/name convention.")
   }
   else {
     name_qualified <- paste0(board$account, "/", name)
+    account_name <- board$account
   }
 
-  account_name <- board$account
   if (identical(board$output_files, TRUE)) {
     account_name <- "https://rstudio-connect-server/content/app-id"
   }


### PR DESCRIPTION
While we want to avoid admins from overriding a pin by mistake when not specifying the fully qualified name, we still want to allow users to collaborate with pins they co-own.