### PR TITLE
Use https by default for s3 boards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9002
+Version: 0.4.4.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pins 0.4.4.9000
 
+## S3
+
+- Default to using HTTPS in S3 boards (#304).
+
 ## RStudio Connect
 
 - Invalid 'account' or 'server' parameters show proper errors (#296).

--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -44,7 +44,7 @@ board_initialize.s3 <- function(board,
   if (nchar(key) == 0)  stop("The 's3' board requires a 'key' parameter.")
   if (nchar(secret) == 0)  stop("The 's3' board requires a 'secret' parameter.")
 
-  s3_url <- paste0("http://", board$bucket, ".", host)
+  s3_url <- paste0("https://", board$bucket, ".", host)
 
   board_register_datatxt(name = board$name,
                          url = s3_url,


### PR DESCRIPTION
Use HTTPS as suggested in https://github.com/rstudio/pins/issues/304