### PR TITLE
Avoid attempting to delete rsconnect pin when upload fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9003
+Version: 0.4.4.9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
   
 - Fix regression introduced in pins 0.4.2 (#253) preventing users from
   collaborating on existing pins they have access to (#302).
+  
+- Avoid deleting pin when upload fails to avoid deleting versions (#306).
 
 # pins 0.4.4
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -185,9 +185,6 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
                                  progress = http_utils_progress("up", size = file.info(normalizePath(bundle))$size))
 
     if (!is.null(upload$error)) {
-      # before we fail, clean up rsconnect content
-      rsconnect_api_delete(board, paste0("/__api__/v1/experimental/content/", guid))
-
       stop("Failed to upload pin: ", upload$error)
     }
 


### PR DESCRIPTION
Just porting fix from https://github.com/rstudio/pins/pull/306/