### PR TITLE
fix #310 : test if path contains query before attempt to download data.txt

### DIFF
--- a/R/pin_extensions.R
+++ b/R/pin_extensions.R
@@ -28,7 +28,7 @@ board_pin_store <- function(board, path, name, description, type, metadata, extr
   dir.create(store_path)
   on.exit(unlink(store_path, recursive = TRUE))
 
-  if (length(path) == 1 && grepl("^http", path) && !grepl("\\.[a-z]{2,4}$", path) && getOption("pins.search.datatxt", TRUE)) {
+  if (length(path) == 1 && grepl("^http", path) && !grepl("\\.[a-z]{2,4}$", path) && !grepl("\\?", path) && getOption("pins.search.datatxt", TRUE)) {
     # attempt to download data.txt to enable public access to boards like rsconnect
     datatxt_path <- file.path(path, "data.txt")
     local_path <- pin_download(datatxt_path, name, board_default(), can_fail = TRUE)


### PR DESCRIPTION
I added a test if URL contains query parameters before attempt to download data.txt to enable public access to boards like rsconnect.

Please see #310 for details.