### PR TITLE
Add tests for using links in large files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9006
+Version: 0.4.4.9007
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Support downloading remote files when service returns incompatible
   `data.txt` file (#310).
+  
+- Support for pins over 100MB in Windows systems (#313).
 
 ## S3
 

--- a/R/pin_extensions.R
+++ b/R/pin_extensions.R
@@ -76,7 +76,7 @@ board_pin_store <- function(board, path, name, description, type, metadata, extr
 
       if (details$something_changed) {
         copy_or_link <- function(from, to) {
-          if (file.exists(from) && file.info(from)$size >= getOption("pins.link.size", 10^8))
+          if (file.exists(from) && file.info(from)$size >= getOption("pins.link.size", 10^8) && .Platform$OS.type != "windows")
             fs::link_create(from, file.path(to, basename(from)))
           else
             file.copy(from, to, recursive = TRUE)

--- a/tests/testthat/test-board-local.R
+++ b/tests/testthat/test-board-local.R
@@ -17,6 +17,10 @@ test_that(paste("can pin() file with auto-generated name in local board"), {
 
 board_test("local", suite = "default")
 
+options(pins.link.size = 1)
+board_test("local", suite = "default", destination = "local board with links")
+options(pins.link.size = NULL)
+
 test_that("local board is registered with versions", {
   board_register("local", cache = tempfile(), versions = TRUE)
   expect_true("local" %in% board_list())


### PR DESCRIPTION
Adding a test that simulates large files through the codepaths that uses symlinks instead of copying files.