### PR TITLE
Add support for AWS V4 signatures

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,10 @@ jobs:
       CRAN: ${{ matrix.cran }}
       TEST_RSCONNECT_APIS: ${{ secrets.TEST_RSCONNECT_APIS }}
       TEST_RSCONNECT_SERVERS: ${{ secrets.TEST_RSCONNECT_SERVERS }}
+      TEST_AWS_BUCKET: "pins-github-tests"
+      TEST_AWS_KEY: "AKIAWDFKE5M2ZHDUORMW"
+      TEST_AWS_REGION: "us-east-2"
+      TEST_AWS_SECRET: ${{ secrets.TEST_AWS_SECRET }}
     steps:
       - uses: actions/checkout@v1
       - uses: r-lib/actions/setup-r@master

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9009
+Version: 0.4.4.9010
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 
 - Default to using HTTPS in S3 boards (#304).
 
+- Add support for AWS V4 signatures when registering S3 boards with
+  `region` parameter (#304)
+
 ## RStudio Connect
 
 - Invalid 'account' or 'server' parameters show proper errors (#296).

--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -1,3 +1,100 @@
+# See https://docs.amazonaws.cn/en_us/general/latest/gr/sigv4-signed-request-examples.html#sig-v4-examples-get-auth-header
+# httr::GET("https://ec2.amazonaws.com?Action=DescribeRegions&Version=2013-10-15", pins:::s3_headers_v4()) %>% httr::text_content()
+s3_headers_v4 <- function(method = "GET",
+                          service = "ec2",
+                          host = "ec2.amazonaws.com",
+                          region = "us-east-1",
+                          endpoint = "https://ec2.amazonaws.com",
+                          request_parameters = "Action=DescribeRegions&Version=2013-10-15") {
+  # Key derivation functions. See:
+  # http://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html#signature-v4-examples-python
+  sign <- function(key, msg) {
+    openssl::sha256(charToRaw(enc2utf8(msg)), key = key)
+  }
+
+  getSignatureKey <- function(key, dateStamp, regionName, serviceName) {
+    kDate <- sign(paste0("AWS4", key), dateStamp)
+    kRegion <- sign(kDate, regionName)
+    kService <- sign(kRegion, serviceName)
+    kSigning <- sign(kService, "aws4_request")
+    kSigning
+  }
+
+  # Read AWS access key from env. variables or configuration file. Best practice is NOT
+  # to embed credentials in code.
+  access_key <- Sys.getenv("AWS_ACCESS_KEY_ID")
+  secret_key <- Sys.getenv("AWS_SECRET_ACCESS_KEY")
+
+  # Create a date for headers and the credential string
+  amzdate <- format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "GMT")
+  datestamp <- format(Sys.time(), "%Y%m%d", tz = "GMT")
+
+  # ************* TASK 1: CREATE A CANONICAL REQUEST *************
+  # http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+
+  # Step 1 is to define the verb (GET, POST, etc.)--already done.
+
+  # Step 2: Create canonical URI--the part of the URI from domain to query
+  # string (use "/" if no path)
+  canonical_uri <- "/"
+
+  # Step 3: Create the canonical query string. In this example (a GET request),
+  # request parameters are in the query string. Query string values must
+  # be URL-encoded (space=%20). The parameters must be sorted by name.
+  # For this example, the query string is pre-formatted in the request_parameters variable.
+  canonical_querystring <- request_parameters
+
+  # Step 4: Create the canonical headers. Header names must be trimmed
+  # and lowercase, and sorted in code point order from low to high.
+  # Note that there is a trailing \n.
+  canonical_headers <- paste0(
+    "host:", host, "\n",
+    "x-amz-date:", amzdate, "\n",
+    "")
+
+  # Step 5: Create the list of signed headers. This lists the headers
+  signed_headers <- "host;x-amz-date"
+
+  # Step 6: Create payload hash. In this example, the payload (body of
+  # the request) contains the request parameters.
+  payload_hash <- digest::digest(enc2utf8(""), serialize = FALSE, algo = "sha256")
+
+  # Step 7: Combine elements to create canonical request
+  canonical_request <- paste0(method, "\n", canonical_uri, "\n", canonical_querystring, "\n", canonical_headers, "\n", signed_headers, "\n", payload_hash)
+
+  # ************* TASK 2: CREATE THE STRING TO SIGN*************
+  # Match the algorithm to the hashing algorithm you use, either SHA-1 or
+  # SHA-256 (recommended)
+  algorithm <- "AWS4-HMAC-SHA256"
+  credential_scope <- paste0(datestamp, "/", board$region, "/", service, "/", "aws4_request")
+  string_to_sign <- paste0(algorithm, "\n",  amzdate, "\n", credential_scope, "\n",  digest::digest(enc2utf8(canonical_request), serialize = FALSE, algo = "sha256"))
+
+  # ************* TASK 3: CALCULATE THE SIGNATURE *************
+  # Create the signing key using the function defined above.
+  signing_key <- getSignatureKey(secret_key, datestamp, region, service)
+
+  # Sign the string_to_sign using the signing_key
+  signature <- openssl::sha256(string_to_sign, key = signing_key) %>% as.character()
+
+  # ************* TASK 4: ADD SIGNING INFORMATION TO THE REQUEST *************
+  # Put the signature information in a header named Authorization.
+  authorization_header <- paste0(
+    algorithm, " ",
+    "Credential=", board$key, "/", credential_scope, ", ",
+    "SignedHeaders=", signed_headers, ", ",
+    "Signature=", signature)
+
+  headers <- httr::add_headers(
+    # "Host" = host,
+    # "Content-Type" = content_type,
+    "x-amz-date" = amzdate,
+    # "x-amz-content-sha256" = amz_content_sha256,
+    "Authorization" = authorization_header
+  )
+
+  headers
+}
+
 s3_headers <- function(board, verb, path, file) {
   date <- format(Sys.time(), "%a, %d %b %Y %H:%M:%S %z")
 
@@ -9,24 +106,29 @@ s3_headers <- function(board, verb, path, file) {
     bucket <- gsub("\\..*", "", path_nohttp)
   }
 
-  content <- paste(
-    verb,
-    "",
-    "application/octet-stream",
-    date,
-    file.path("", bucket, path),
-    sep = "\n"
-  )
+  if (!identical(board$region, NULL)) {
 
-  signature <- openssl::sha1(charToRaw(content), key = board$secret) %>%
-    base64enc::base64encode()
+  }
+  else {
+    content <- paste(
+      verb,
+      "",
+      "application/octet-stream",
+      date,
+      file.path("", bucket, path),
+      sep = "\n"
+    )
 
-  headers <- httr::add_headers(
-    Host = paste0(bucket, ".", board$host),
-    Date = date,
-    `Content-Type` = "application/octet-stream",
-    Authorization = paste0("AWS ", board$key, ":", signature)
-  )
+    signature <- openssl::sha1(charToRaw(content), key = board$secret) %>%
+      base64enc::base64encode()
+
+    headers <- httr::add_headers(
+      Host = paste0(bucket, ".", board$host),
+      Date = date,
+      `Content-Type` = "application/octet-stream",
+      Authorization = paste0("AWS ", board$key, ":", signature)
+    )
+  }
 
   headers
 }

--- a/tests/testthat/test-board-s3.R
+++ b/tests/testthat/test-board-s3.R
@@ -3,6 +3,8 @@ context("board s3")
 test_s3_bucket <- Sys.getenv("TEST_AWS_BUCKET", "")
 test_s3_key <- Sys.getenv("TEST_AWS_KEY", "")
 test_s3_secret <- Sys.getenv("TEST_AWS_SECRET", "")
+test_s3_region <- Sys.getenv("TEST_AWS_REGION", "")
+if (identical(test_s3_region, "")) test_s3_region <- NULL
 
 test_that("board contains proper s3 headers", {
   headers <- names(s3_headers(list(), "PUT", "x")$headers)
@@ -23,7 +25,8 @@ test_s3_suite <- function(suite, versions = NULL) {
                    key = test_s3_key,
                    secret = test_s3_secret,
                    versions = versions,
-                   cache = tempfile())
+                   cache = tempfile(),
+                   region = test_s3_region)
   }
 
   if (test_board_is_registered("s3")) {

--- a/vignettes/boards-s3.Rmd
+++ b/vignettes/boards-s3.Rmd
@@ -33,6 +33,15 @@ board_register("s3", bucket = "pinsbucket",
                      secret = "ABCABCABCABCABCABCABCABCABCABCABCABCABCA==")
 ```
 
+It is highly recommended to specify the region when registering a board. Since this enables `pins` to use the V4 signature which is now required in some AWS regions:
+
+```{r eval=FALSE}
+board_register("s3", bucket = "pinsbucket",
+                     key = "AAAAAAAAAAAAAAAAAAAA",
+                     secret = "ABCABCABCABCABCABCABCABCABCABCABCABCABCA==",
+                     region = "us-west-2")
+```
+
 Once the board is registered, you can pin and search using `pin()`, `pin_get()` and `pin_find()`.
 
 ## Pinning


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/304, important since some AWS regions do not longer support V2 signatures.