### PR TITLE
Silence no encoding warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9010
+Version: 0.4.4.9011
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 - Avoid Windows crashing in `pin()` under some locales (#127).
 
+## Boards
+
+- Silenced 'no encoding supplied' warning (#330).
+
 ## S3
 
 - Default to using HTTPS in S3 boards (#304).

--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -225,7 +225,7 @@ board_pin_find.datatxt <- function(board, text, name, extended = FALSE, ...) {
 }
 
 datatxt_response_content <- function(response) {
-  content <- httr::content(response)
+  content <- httr::content(response, encoding = "UTF-8")
   if (is.raw(content)) {
     content <- rawToChar(content)
   }

--- a/R/board_kaggle.R
+++ b/R/board_kaggle.R
@@ -44,7 +44,7 @@ kaggle_upload_resource <- function(path, board) {
 
   if (httr::http_error(results)) stop("Upload registration failed with status ", httr::status_code(results))
 
-  parsed <- httr::content(results)
+  parsed <- httr::content(results, encoding = "UTF-8")
 
   if (!identical(parsed$error, NULL)) stop("Upload registration failed: ", parsed$error)
 
@@ -56,7 +56,7 @@ kaggle_upload_resource <- function(path, board) {
 
   if (httr::http_error(results)) stop("Upload failed with status ", httr::status_code(results))
 
-  parsed <- httr::content(results)
+  parsed <- httr::content(results, encoding = "UTF-8")
 
   if (!identical(parsed$error, NULL)) stop("Upload failed: ", parsed$error)
 
@@ -103,7 +103,7 @@ kaggle_create_resource <- function(name, description, token, type, metadata, not
 
   if (httr::http_error(results)) stop("Resource creation failed with status ", httr::status_code(results))
 
-  parsed <- httr::content(results)
+  parsed <- httr::content(results, encoding = "UTF-8")
 
   if (!identical(parsed$error, NULL)) stop("Resource creation failed: ", parsed$error)
 
@@ -194,7 +194,7 @@ board_pin_search_kaggle <- function(board, text = NULL, base_url = "https://www.
   results <- httr::GET(url, kaggle_auth(board))
   if (httr::http_error(results)) stop("Finding pin failed with status ", httr::status_code(results))
 
-  httr::content(results)
+  httr::content(results, encoding = "UTF-8")
 }
 
 board_pin_find.kaggle <- function(board, text, extended = FALSE, ...) {
@@ -248,7 +248,7 @@ kaggle_competition_files <- function(board, name) {
   results <- httr::GET(url, kaggle_auth(board))
   if (httr::http_error(results)) stop("Finding pin failed with status ", httr::status_code(results))
 
-  httr::content(results)
+  httr::content(results, encoding = "UTF-8")
 }
 
 board_pin_get.kaggle <- function(board, name, extract = NULL, version = NULL, ...) {
@@ -311,7 +311,7 @@ board_pin_versions.kaggle <- function(board, name, ...) {
 
   if (httr::http_error(response)) stop("Failed to view dataset with status ", httr::status_code(response))
 
-  parsed <- httr::content(response)
+  parsed <- httr::content(response, encoding = "UTF-8")
 
   if (httr::http_error(response))
     stop("Failed to retrieve commits from ", board$repo, ": ", parsed$message)

--- a/R/board_rsconnect_api.R
+++ b/R/board_rsconnect_api.R
@@ -33,10 +33,10 @@ rsconnect_api_get <- function(board, path) {
   result <- httr::GET(url, rsconnect_api_auth_headers(board, path, "GET"))
 
   if (httr::http_error(result)) {
-    stop("Failed to retrieve ", url, " ", as.character(httr::content(result)))
+    stop("Failed to retrieve ", url, " ", as.character(httr::content(result, encoding = "UTF-8")))
   }
 
-  result %>% httr::content()
+  result %>% httr::content(encoding = "UTF-8")
 }
 
 rsconnect_api_delete <- function(board, path) {
@@ -44,10 +44,10 @@ rsconnect_api_delete <- function(board, path) {
                rsconnect_api_auth_headers(board, path, "DELETE"))
 
   if (httr::http_error(result)) {
-    stop("Failed to delete ", path, " ", as.character(httr::content(result)))
+    stop("Failed to delete ", path, " ", as.character(httr::content(result, encoding = "UTF-8")))
   }
 
-  result %>% httr::content()
+  result %>% httr::content(encoding = "UTF-8")
 }
 
 rsconnect_api_post <- function(board, path, content, encode, progress = NULL) {
@@ -72,7 +72,7 @@ rsconnect_api_post <- function(board, path, content, encode, progress = NULL) {
                          body = content,
                          rsconnect_api_auth_headers(board, url, "POST", content),
                          progress)
-    content <- httr::content(result)
+    content <- httr::content(result, encoding = "UTF-8")
 
     if (httr::http_error(result)) {
       list(

--- a/R/pin_download.R
+++ b/R/pin_download.R
@@ -110,7 +110,7 @@ pin_download_one <- function(path,
 
         if (httr::http_error(result)) {
           error <- paste0(httr::http_status(result)$message, ". Failed to download remote file: ", path)
-          pin_log(as.character(httr::content(result)))
+          pin_log(as.character(httr::content(result, encoding = "UTF-8")))
 
           report_error(error)
         }


### PR DESCRIPTION
It is common to get the following warnings intermittently, so worth assuming the encoding:

```r
> pin_remove("iris", board = "s3path")
No encoding supplied: defaulting to UTF-8.
No encoding supplied: defaulting to UTF-8.
No encoding supplied: defaulting to UTF-8.
``` 