### PR TITLE
Add support for 'path' parameter across cloud storage boards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9011
+Version: 0.4.4.9012
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,22 @@
 
 - Default to using HTTPS in S3 boards (#304).
 
-- Add support for AWS V4 signatures when registering S3 boards with
+- Support for AWS V4 signatures when registering S3 boards with
   `region` parameter (#304)
+  
+- Support for `path` to register a board under a subpath (#200).
+
+## Azure
+
+- Support for `path` to register a board under a subpath (#200).
+
+## DigitalOcean
+
+- Support for `path` to register a board under a subpath (#200).
+
+## Google Cloud
+
+- Support for `path` to register a board under a subpath (#200).
 
 ## RStudio Connect
 

--- a/R/board_registration.R
+++ b/R/board_registration.R
@@ -227,6 +227,7 @@ board_register_datatxt <- function(url,
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
 #' @param host The host to use for storage, defaults to \code{"s3.amazonaws.com"}.
 #' @param region The region to use, required in some AWS regions and to enable V4 signatures.
+#' @param path The subdirectory in the repo where the pins will be stored.
 #' @param ... Additional parameters required to initialize a particular board.
 #'
 #' @details
@@ -251,6 +252,7 @@ board_register_s3 <- function(name = "s3",
                               cache = board_cache_path(),
                               host = "s3.amazonaws.com",
                               region = NULL,
+                              path = NULL,
                               ...) {
   board_register("s3",
                  name = name,
@@ -259,6 +261,7 @@ board_register_s3 <- function(name = "s3",
                  secret = secret,
                  cache = cache,
                  region = region,
+                 path = path,
                  ...)
 }
 
@@ -275,6 +278,7 @@ board_register_s3 <- function(name = "s3",
 #' @param key The key of the Azure Storage container Defaults to the \code{AZURE_STORAGE_KEY} environment
 #'   variable.
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
+#' @param path The subdirectory in the repo where the pins will be stored.
 #' @param ... Additional parameters required to initialize a particular board.
 #'
 #' @details
@@ -297,6 +301,7 @@ board_register_azure <- function(name = "azure",
                                  account = Sys.getenv("AZURE_STORAGE_ACCOUNT"),
                                  key = Sys.getenv("AZURE_STORAGE_KEY"),
                                  cache = board_cache_path(),
+                                 path = NULL,
                                  ...) {
   board_register("azure",
                  name = name,
@@ -304,6 +309,7 @@ board_register_azure <- function(name = "azure",
                  container = container,
                  key = key,
                  cache = cache,
+                 path = path,
                  ...)
 }
 
@@ -317,6 +323,7 @@ board_register_azure <- function(name = "azure",
 #'   variable.
 #' @param token The access token of the Google Cloud Storage container. Defaults to use the Google Cloud SDK if configured.
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
+#' @param path The subdirectory in the repo where the pins will be stored.
 #' @param ... Additional parameters required to initialize a particular board.
 #'
 #' @details
@@ -336,12 +343,14 @@ board_register_gcloud <- function(name = "gcloud",
                                   bucket = Sys.getenv("GCLOUD_STORAGE_BUCKET"),
                                   token = NULL,
                                   cache = board_cache_path(),
+                                  path = NULL,
                                   ...) {
   board_register("gcloud",
                  name = name,
                  bucket = bucket,
                  token = token,
                  cache = cache,
+                 path = path,
                  ...)
 }
 
@@ -361,6 +370,7 @@ board_register_gcloud <- function(name = "gcloud",
 #'   variable.
 #' @param cache The local folder to use as a cache, defaults to \code{board_cache_path()}.
 #' @param host The host to use for storage, defaults to \code{"digitaloceanspaces.com"}.
+#' @param path The subdirectory in the repo where the pins will be stored.
 #' @param ... Additional parameters required to initialize a particular board.
 #'
 #' @details
@@ -383,6 +393,7 @@ board_register_dospace <- function(name = "dospace",
                                    datacenter = Sys.getenv("DO_DATACENTER"),
                                    cache = board_cache_path(),
                                    host = "digitaloceanspaces.com",
+                                   path = NULL,
                                    ...) {
   board_register("dospace",
                  name = name,
@@ -392,5 +403,6 @@ board_register_dospace <- function(name = "dospace",
                  datacenter = datacenter,
                  cache = cache,
                  host = host,
+                 path = path,
                  ...)
 }

--- a/man/board_register_azure.Rd
+++ b/man/board_register_azure.Rd
@@ -10,6 +10,7 @@ board_register_azure(
   account = Sys.getenv("AZURE_STORAGE_ACCOUNT"),
   key = Sys.getenv("AZURE_STORAGE_KEY"),
   cache = board_cache_path(),
+  path = NULL,
   ...
 )
 }
@@ -26,6 +27,8 @@ variable.}
 variable.}
 
 \item{cache}{The local folder to use as a cache, defaults to \code{board_cache_path()}.}
+
+\item{path}{The subdirectory in the repo where the pins will be stored.}
 
 \item{...}{Additional parameters required to initialize a particular board.}
 }

--- a/man/board_register_dospace.Rd
+++ b/man/board_register_dospace.Rd
@@ -12,6 +12,7 @@ board_register_dospace(
   datacenter = Sys.getenv("DO_DATACENTER"),
   cache = board_cache_path(),
   host = "digitaloceanspaces.com",
+  path = NULL,
   ...
 )
 }
@@ -33,6 +34,8 @@ variable.}
 \item{cache}{The local folder to use as a cache, defaults to \code{board_cache_path()}.}
 
 \item{host}{The host to use for storage, defaults to \code{"digitaloceanspaces.com"}.}
+
+\item{path}{The subdirectory in the repo where the pins will be stored.}
 
 \item{...}{Additional parameters required to initialize a particular board.}
 }

--- a/man/board_register_gcloud.Rd
+++ b/man/board_register_gcloud.Rd
@@ -9,6 +9,7 @@ board_register_gcloud(
   bucket = Sys.getenv("GCLOUD_STORAGE_BUCKET"),
   token = NULL,
   cache = board_cache_path(),
+  path = NULL,
   ...
 )
 }
@@ -21,6 +22,8 @@ variable.}
 \item{token}{The access token of the Google Cloud Storage container. Defaults to use the Google Cloud SDK if configured.}
 
 \item{cache}{The local folder to use as a cache, defaults to \code{board_cache_path()}.}
+
+\item{path}{The subdirectory in the repo where the pins will be stored.}
 
 \item{...}{Additional parameters required to initialize a particular board.}
 }

--- a/man/board_register_s3.Rd
+++ b/man/board_register_s3.Rd
@@ -12,6 +12,7 @@ board_register_s3(
   cache = board_cache_path(),
   host = "s3.amazonaws.com",
   region = NULL,
+  path = NULL,
   ...
 )
 }
@@ -32,6 +33,8 @@ variable.}
 \item{host}{The host to use for storage, defaults to \code{"s3.amazonaws.com"}.}
 
 \item{region}{The region to use, required in some AWS regions and to enable V4 signatures.}
+
+\item{path}{The subdirectory in the repo where the pins will be stored.}
 
 \item{...}{Additional parameters required to initialize a particular board.}
 }


### PR DESCRIPTION
Add support for `path` parameter to S3, Azure, Google Cloud and DigitalOceab boards. When `path` is specified, the boards will get created under a sub-directory in the bucket. See https://github.com/rstudio/pins/issues/200