### PR TITLE
Preserve column names in RStudio Connect data frame previews

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9013
+Version: 0.4.4.9014
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,8 @@
 
 - Adjust pin preview to only display 1K rows instead of 10K (#315).
 
+- Avoid changing columns names on data frame preview (#190).
+
 # pins 0.4.4
 
 ## Pins

--- a/R/board_rsconnect_bundle.R
+++ b/R/board_rsconnect_bundle.R
@@ -57,7 +57,7 @@ rsconnect_bundle_create.data.frame <- function(x, temp_dir, name, board, account
         rep("...", nrow(x_preview))
     } else
       e
-  }), stringsAsFactors = FALSE)
+  }), stringsAsFactors = FALSE, check.names = FALSE)
 
   data_preview <- list(
     columns = lapply(colnames(x_preview), function(e) {


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/190:

```r
tibble::tibble(`With space`=c(1,3)) %>%
  pin(name = "pin-with-spaced-col", description = "tibble with column name space", board = "rsconnect")
```

<img width="1083" alt="Screen Shot 2020-12-15 at 2 30 59 PM" src="https://user-images.githubusercontent.com/3478847/102280845-baa77600-3ee2-11eb-8c69-aef03f492010.png">
