### PR TITLE
Avoid using regexp in pin_find() local boards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9015
+Version: 0.4.4.9016
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@
 
 - Silenced 'no encoding supplied' warning (#330).
 
+## Local
+
+- `pin_find()` no longer searches text with an undocumented
+  regular expression syntax (#270).
+
 ## S3
 
 - Default to using HTTPS in S3 boards (#304).

--- a/R/pin_registry.R
+++ b/R/pin_registry.R
@@ -68,7 +68,7 @@ pin_registry_find <- function(text, component) {
   results <- pin_results_from_rows(entries)
 
   if (is.character(text)) {
-    results <- results[grepl(text, results$name),]
+    results <- results[grepl(text, results$name, fixed = TRUE),]
   }
 
   results


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/270 to avoid searching local boards with an undocumented regular expression.