### PR TITLE
Delete tag when deleting or updating a GitHub pin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pins
 Type: Package
 Title: Pin, Discover and Share Resources
-Version: 0.4.4.9018
+Version: 0.4.4.9019
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,9 @@
 
 - Add support for large file in private repo releases (#292).
 
+- When a board is registered with `versions = FALSE`, GitHub
+  tags are also delete when large files are present (#285).
+
 ## RStudio Connect
 
 - Invalid 'account' or 'server' parameters show proper errors (#296).

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -150,6 +150,11 @@ github_delete_release <- function(board, release_tag) {
     if (httr::http_error(response)) {
       pin_log("Failed to delete release ", release_id)
     }
+
+    response <- httr::DELETE(github_url(board, branch = NULL, paste0("/git/refs/", release_tag)), github_headers(board))
+    if (httr::http_error(response)) {
+      pin_log("Failed to delete tag ", release_tag)
+    }
   }
 }
 

--- a/R/board_github.R
+++ b/R/board_github.R
@@ -151,7 +151,7 @@ github_delete_release <- function(board, release_tag) {
       pin_log("Failed to delete release ", release_id)
     }
 
-    response <- httr::DELETE(github_url(board, branch = NULL, paste0("/git/refs/", release_tag)), github_headers(board))
+    response <- httr::DELETE(github_url(board, branch = NULL, paste0("/git/refs/tags/", release_tag)), github_headers(board))
     if (httr::http_error(response)) {
       pin_log("Failed to delete tag ", release_tag)
     }


### PR DESCRIPTION
Fix for https://github.com/rstudio/pins/issues/285 -- Notice this is only applicable to boards registered with `versions = FALSE`; otherwise, releases are not removed since we want to be able to restore modified and perhaps even deleted pins.

One can question if `pin_remove()` should also remove all versions to match other boards like Kaggle and RStudio Connect; however, that would involve also modifying the repo commit history, which is almost never a good idea.