### PR TITLE
Fix S3 for non-US LC_TIME

### DIFF
--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -109,7 +109,16 @@ s3_headers_v4 <- function(board, verb, path, filepath) {
 }
 
 s3_headers <- function(board, verb, path, file) {
-  date <- format(Sys.time(), "%a, %d %b %Y %H:%M:%S %z")
+  get_date <-
+    function() {
+      loc <- Sys.getlocale(category = "LC_TIME")
+      on.exit(Sys.setlocale(category = "LC_TIME", locale = loc))
+      Sys.setlocale(category = "LC_TIME", locale = "C")
+
+      strftime(Sys.time(), "%a, %d %b %Y %H:%M:%S %z", tz = "UTC")
+    }
+
+  date <- get_date()
 
   # allow full urls to allow arbitrary file downloads
   bucket <- board$bucket


### PR DESCRIPTION
Currently s3 doesn't always work for non-US locales as sometimes the names of weekdays and months are different.

AFAIK, the only way to get a US time string in R is to set the `LC_TIME` locale for the duration of the `Sys.time()` call.