### PR TITLE
Access type should be added to pin creation in rsconnect. Add test.

### DIFF
--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -123,7 +123,8 @@ board_pin_create.rsconnect <- function(board, path, name, metadata, code = NULL,
                                     app_mode = "static",
                                     content_category = "pin",
                                     name = name,
-                                    description = board_metadata_to_text(metadata, metadata$description)
+                                    description = board_metadata_to_text(metadata, metadata$description),
+                                    access_type = access_type
                                   ))
       if (!is.null(content$error)) {
         # we might fail to create pins that exists (code 26) but are not shown as pins since they fail while being created

--- a/R/board_test.R
+++ b/R/board_test.R
@@ -153,6 +153,9 @@ board_test_default <- function(board, exclude, destination) {
 
     pin(text_file, pin_name, board = board, access_type = access_type)
     deps$expect_equal(pin_info(pin_name, board)$access_type, access_type)
+
+    # Clean up
+    try(pin_remove(pin_name, board), silent = T)
   })
 }
 

--- a/R/board_test.R
+++ b/R/board_test.R
@@ -144,6 +144,16 @@ board_test_default <- function(board, exclude, destination) {
 
     deps$expect_equal(readLines(cached_path), "hello world")
   })
+
+  deps$test_that(paste("can pin a new piece of content with access_type not acl"), {
+    pin_name <- "access_type_test"
+    access_type <- "logged_in"
+    # Ensure it doesn't exist already
+    try(pin_remove(pin_name, board), silent = T)
+
+    pin(text_file, pin_name, board = board, access_type = access_type)
+    deps$expect_equal(pin_info(pin_name, board)$access_type, access_type)
+  })
 }
 
 board_test_versions <- function(board, exclude, destination) {


### PR DESCRIPTION
A bug was reported through rstudio connect support that pins were not being created with the requested access_type, and instead would be created with the `acl` access_type.

New content created using the `pin` function crafts its API call here: (note the lack of an `access_type` argument passed)

https://github.com/rstudio/pins/blob/master/R/board_rsconnect.R#L120

Updating a pin using the `pin` function calls the API here:

https://github.com/rstudio/pins/blob/master/R/board_rsconnect.R#L151

This code adds the `access_type` argument and additionally updates tests such that we can prove we've fixed the bug.