### PR TITLE
Handle files in directories in pin_download_one(), closes #357

### DIFF
--- a/R/pin_download.R
+++ b/R/pin_download.R
@@ -97,6 +97,7 @@ pin_download_one <- function(path,
 
         if (remove_query) download_name <- strsplit(download_name, "\\?")[[1]][1]
         destination_path <- file.path(temp_path, download_name)
+        dir.create(dirname(destination_path), recursive = T, showWarnings = F)
         pin_log("Downloading ", path, " to ", destination_path)
         details$something_changed <- TRUE
 


### PR DESCRIPTION
The PR ensures that before downloading a file in `pin_download_one()`, all directories contained in the destination path are created on disk inside the temp dir before the download is attempted.

This handles cases where a pin contains files in directories, which currently causes an error.

See issue #357 for details.﻿

Reprex to verify this, relying on an existing pin with a file inside a directory. 

``` r
library(pins)
github_public <- pins::board_register_github(repo = "petrbouchal/storage-public", branch = "main")
x <- pin_get("arrow_ds", board = github_public, cache = F)
```

<sup>Created on 2021-01-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>