### PR TITLE
Pass correct index_file to board_datatxt_headers

### DIFF
--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -9,16 +9,17 @@ datatxt_refresh_index <- function(board) {
   if (is.null(board$url)) stop("Invalid 'url' in '", board$name, "' board.")
 
   index_file <- "data.txt"
-  if (identical(board$index_randomize, TRUE)) {
-    index_file <- paste0(index_file, "?rand=", stats::runif(1) * 10^8)
-  }
-
   index_url <- file_path_null(board$url, board$subpath, index_file)
+
+  index_file_get <- file_path_null(board$subpath, "data.txt")
+  if (identical(board$index_randomize, TRUE)) {
+    index_file_get <- paste0(index_file_get, "?rand=", stats::runif(1) * 10^8)
+  }
 
   temp_index <- tempfile()
   response <- httr::GET(index_url,
                         httr::write_disk(temp_index, overwrite = TRUE),
-                        board_datatxt_headers(board, "data.txt"))
+                        board_datatxt_headers(board, index_file_get))
 
   local_index <- file.path(board_local_storage(board$name, board = board), "data.txt")
   current_index <- board_manifest_get(local_index, default_empty = TRUE)

--- a/R/board_datatxt.R
+++ b/R/board_datatxt.R
@@ -11,7 +11,7 @@ datatxt_refresh_index <- function(board) {
   index_file <- "data.txt"
   index_url <- file_path_null(board$url, board$subpath, index_file)
 
-  index_file_get <- file_path_null(board$subpath, "data.txt")
+  index_file_get <- file_path_null(board$subpath, index_file)
   if (identical(board$index_randomize, TRUE)) {
     index_file_get <- paste0(index_file_get, "?rand=", stats::runif(1) * 10^8)
   }


### PR DESCRIPTION
In `datatxt_refresh_index` the index file passed to `board_datatxt_headers` in `httr::GET(..)` was `"data.txt"` but - in order to work with boards that have a subpath - the index file passed should be `index_file_get <- file_path_null(board$subpath, "data.txt")`.

This is fixed in this PR. For obvious reasons I couldn't run the tests that are skipped automatically because I wasn't able to connect to the various remote platforms. All other tests passed.

Fixes issue #359 