### PR TITLE
build dev site

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -3,6 +3,9 @@ url: https://pins.rstudio.com
 home:
   strip_header: true
 
+development:
+  mode: auto
+
 reference:
 - title: "Pins"
   desc: "Functions for pinning, finding, retrieving and sharing remote resources."


### PR DESCRIPTION
before pins 1.0 is available on CRAN it may confuse current connect users that the pins docs and connect docs are out of sync (it confused me).