### PR TITLE
Change .htm to .html in Vignettes

### DIFF
--- a/vignettes/use-cases/automate-dataset-updates.Rmd
+++ b/vignettes/use-cases/automate-dataset-updates.Rmd
@@ -5,7 +5,7 @@ output:
     df_print: paged
 ---
 
-After datasets are shared (as showcased in the [Reuse Tidy Datasets](reuse-tidy-datasets.htm) use case), it is often useful to also consider automating this process. This is especially interesting for datasets that tend to get out-of-date constantly.
+After datasets are shared (as showcased in the [Reuse Tidy Datasets](reuse-tidy-datasets.html) use case), it is often useful to also consider automating this process. This is especially interesting for datasets that tend to get out-of-date constantly.
 
 For example, if we were interested in updating a pin to track daily news from the [BBC World News RSS](http://feeds.bbci.co.uk/news/world/rss.xml), we could create the following [R Markdown](https://rmarkdown.rstudio.com/) report to download the RSS feed, tidy the news, and publish a pin with the up-to-date news:
 

--- a/vignettes/use-cases/create-data-pipelines.Rmd
+++ b/vignettes/use-cases/create-data-pipelines.Rmd
@@ -5,7 +5,7 @@ output:
     df_print: paged
 ---
 
-Once you have shared datasets (manually created by [Reusing Tidy Datasets](reuse-tidy-datasets.htm) or by [Automating Dataset Updates](automate-dataset-updates.html)), you can also consider creating code that depends on one or many pins to further process datasets or pin other objects like visualizations, models, and so on.
+Once you have shared datasets (manually created by [Reusing Tidy Datasets](reuse-tidy-datasets.html) or by [Automating Dataset Updates](automate-dataset-updates.html)), you can also consider creating code that depends on one or many pins to further process datasets or pin other objects like visualizations, models, and so on.
 
 For instance, we could use the `worldnews` pin to create a deep learning model on a daily schedule. One of the state-of-the-art language models is [GPT-2](https://openai.com/blog/better-language-models/), which we can also use from R through the [gpt2](https://github.com/r-tensorflow/gpt2/) package.
 

--- a/vignettes/use-cases/update-plumber-and-shiny-apps.Rmd
+++ b/vignettes/use-cases/update-plumber-and-shiny-apps.Rmd
@@ -9,7 +9,7 @@ Once you [create data pipelines](create-data-pipelines.html), you can consider r
 
 When using Plumber, you can simply use `pin_get()` since this function is smart-enough to first check for updates before the resource is retrieved When using Shiny, you can use `pin_reactive()` which automatically transforms the pin's resource into a reactive to use from your application.
 
-We can improve the pipeline from the [Create Data Pipelines](create-data-pipelines.htm) use-case by properly generating a web application to display the auto-generated news.
+We can improve the pipeline from the [Create Data Pipelines](create-data-pipelines.html) use-case by properly generating a web application to display the auto-generated news.
 
 A Shiny application that reuses the `news-generated` pin looks as follows:
 


### PR DESCRIPTION
There are 3 broken links in the vignettes/examples due to `.htm` endings rather than `.html`. This PR corrects the file ending so that they can link to the correct pieces of content.