### PR TITLE
Ensure that pin_upload()/pin_download() can handle multiple paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,8 +12,7 @@
     `pin_read()` and `pin_write()` work with R objects. If you want to 
     work with files on disk (because, for example, you need to use file type
     that isn't natively supported), you can use `pin_download()` and 
-    `pin_upload()`. `pin_upload()` takes a path and `pin_download()` returns
-    a path.
+    `pin_upload()`.
 
 * All boards now have a `board_` function that you use to create a board,
   instead of registering it. This takes away the magic of which board a 

--- a/R/board_local.R
+++ b/R/board_local.R
@@ -93,11 +93,11 @@ board_pin_upload.pins_board_local <- function(board, name, path, metadata,
 
   if (!versioned) {
     if (length(pin_meta$versions) == 0) {
-      pins_inform(paste0("Creating new version '", metadata$file_hash, "'"))
+      pins_inform(paste0("Creating new version '", metadata$pin_hash, "'"))
     } else if (length(pin_meta$versions) == 1) {
       pins_inform(paste0(
         "Replacing version '", pin_meta$versions, "'",
-        " with '", metadata$file_hash, "'"
+        " with '", metadata$pin_hash, "'"
       ))
       fs::dir_delete(fs::path(path_pin, pin_meta$versions))
       pin_meta$versions <- NULL
@@ -108,16 +108,16 @@ board_pin_upload.pins_board_local <- function(board, name, path, metadata,
       ))
     }
   } else {
-    pins_inform(paste0("Creating new version '", metadata$file_hash, "'"))
+    pins_inform(paste0("Creating new version '", metadata$pin_hash, "'"))
   }
 
-  path_version <- fs::path(path_pin, metadata$file_hash)
+  path_version <- fs::path(path_pin, metadata$pin_hash)
   fs::dir_create(path_version)
   fs::file_copy(path, path_version, overwrite = TRUE)
   write_meta(metadata, path_version)
 
   # Add to list of versions so we know which is most recent
-  pin_meta$versions <- c(pin_meta$versions, metadata$file_hash)
+  pin_meta$versions <- c(pin_meta$versions, metadata$pin_hash)
   write_meta(pin_meta, path_pin)
 }
 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -224,13 +224,13 @@ board_pin_download.pins_board_rsconnect <- function(board, name, version = NULL,
   rsc_download(board, url, pin_path, "data.txt")
 
   meta <- read_meta(pin_path)
-  for (path in meta$path) {
-    rsc_download(board, url, pin_path, path)
+  for (file in meta$file) {
+    rsc_download(board, url, pin_path, file)
   }
 
   list(
     dir = pin_path,
-    path = fs::path(pin_path, meta$path),
+    path = fs::path(pin_path, meta$file),
     meta = meta
   )
 }
@@ -328,6 +328,7 @@ board_pin_create.pins_board_rsconnect <- function(board, path, name, metadata, c
                                        ...) {
 
   path <- fs::dir_ls(path)
+  metadata$file <- fs::path_file(path)
 
   board_pin_upload.pins_board_rsconnect(
     board = board,

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -206,7 +206,7 @@ board_pin_versions.pins_board_rsconnect <- function(board, name, ...) {
 #' @export
 board_pin_download.pins_board_rsconnect <- function(board, name, version = NULL, ...) {
 
-  content <- rsc_content_find(board, name, quiet = FALSE)
+  content <- rsc_content_find(board, name)
 
   url <- content$content_url
   if (!is.null(version)) {

--- a/R/board_rsconnect_bundle.R
+++ b/R/board_rsconnect_bundle.R
@@ -6,7 +6,6 @@ rsc_bundle <- function(board, name, path, metadata, x = NULL, bundle_path = temp
   fs::file_copy(path, fs::path(bundle_path, fs::path_file(path)))
 
   # * data.txt (used to retrieve pins)
-  metadata$path <- fs::path_file(path)
   yaml::write_yaml(metadata, fs::path(bundle_path, "data.txt"))
 
   # * index.html
@@ -54,7 +53,7 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
   data_preview <- rsc_bundle_preview_data(x)
 
   data <- list(
-    pin_files = paste0("<a href=\"", metadata$path, "\">", metadata$path, "</a>", collapse = ", "),
+    pin_files = paste0("<a href=\"", metadata$file, "\">", metadata$file, "</a>", collapse = ", "),
     data_preview = jsonlite::toJSON(data_preview, auto_unbox = TRUE),
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
     pin_name = paste0(board$account, "/", name),

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -30,7 +30,7 @@ pin_read <- function(board, name, version = NULL, hash = NULL) {
   pin <- board_pin_download(board, name, version = version)
 
   if (!is.null(hash)) {
-    pin_hash <- hash_file(pin$path)
+    pin_hash <- pin_hash(pin$path)
     if (!is_prefix(hash, pin_hash)) {
       abort(paste0(
         "Specified hash '", hash, "' doesn't match pin hash '", pin_hash, "'"
@@ -112,11 +112,11 @@ object_meta <- function(x) {
 standard_meta <- function(path, type, desc = NULL) {
   list(
     file = fs::path_file(path),
+    file_size = as.integer(fs::file_size(path)),
+    pin_hash = pin_hash(path),
     type = type,
     descripton = desc,
     date = format(Sys.time(), "%Y-%m-%dT%H:%M:%S", tz = "UTC"),
-    file_size = as.integer(fs::file_size(path)),
-    file_hash = hash_file(path),
     api_version = 1
   )
 }
@@ -179,6 +179,15 @@ object_load <- function(path, meta) {
 
 is_prefix <- function(prefix, string) {
   substr(string, 1, nchar(prefix)) == prefix
+}
+
+pin_hash <- function(paths) {
+  if (length(paths) == 1) {
+    hash_file(paths)
+  } else {
+    hashes <- map_chr(paths, hash_file)
+    hash(hashes)
+  }
 }
 
 hash_file <- function(path) {

--- a/R/pin-upload-download.R
+++ b/R/pin-upload-download.R
@@ -5,6 +5,8 @@
 #'
 #' @inheritParams pin_read
 #' @param ... Additional arguments passed on to board pin methods.
+#' @return `pin_download()` returns a character vector of file paths;
+#'   `pin_upload()` returns `board`, invisibly.
 #' @export
 #' @examples
 #' board <- board_temp()
@@ -22,15 +24,16 @@ pin_download <- function(board, name, ...) {
 
 #' @export
 #' @rdname pin_download
-#' @param path Path to file to upload to `board`.
+#' @param path A character vector of file paths to upload to `board`.
 pin_upload <- function(board, path, name = NULL, desc = NULL, metadata = list(), ...) {
   check_board(board)
-  if (!is_string(path)) {
-    abort("`path` must be a string")
-  } else if (!fs::file_exists(path)) {
-    abort("`path` must exist")
+  if (!is.character(path)) {
+    abort("`path` must be a character vector")
   }
-  if (is.null(name)) {
+  if (!all(fs::file_exists(path))) {
+    abort("All elements of `path` must exist")
+  }
+  if (is.null(name) && length(path) == 1) {
     name <- fs::path_file(path)
     inform(paste0("Guessing `name = '", name, "'`"))
   } else {
@@ -39,5 +42,7 @@ pin_upload <- function(board, path, name = NULL, desc = NULL, metadata = list(),
 
   metadata <- utils::modifyList(metadata, standard_meta(path, NULL, desc))
   board_pin_upload(board, name, path, metadata, ...)
+
+  invisible(board)
 }
 

--- a/man/pin_download.Rd
+++ b/man/pin_download.Rd
@@ -17,12 +17,16 @@ pin_upload(board, path, name = NULL, desc = NULL, metadata = list(), ...)
 
 \item{...}{Additional arguments passed on to board pin methods.}
 
-\item{path}{Path to file to upload to \code{board}.}
+\item{path}{A character vector of file paths to upload to \code{board}.}
 
 \item{desc}{A text description of the pin; most important for
 shared boards so that others can understand what the pin contains.}
 
 \item{metadata}{A list containing additional metadata to store with the pin.}
+}
+\value{
+\code{pin_download()} returns a character vector of file paths;
+\code{pin_upload()} returns \code{board}, invisibly.
 }
 \description{
 This is a lower-level interface than \code{pin_read()} and \code{pin_write()} that

--- a/tests/testthat/_snaps/board_rsconnect_bundle.md
+++ b/tests/testthat/_snaps/board_rsconnect_bundle.md
@@ -3,7 +3,7 @@
     Code
       board <- list(account = "TEST", server = "example.com")
       df <- data.frame(x = 1:2, y = 2:1)
-      metadata <- list(path = "test.csv")
+      metadata <- list(file = "test.csv")
       cat(rsc_bundle_preview_index(board, "test", df, metadata))
     Output
       <!doctype html>
@@ -54,7 +54,7 @@
           <section>
             <h3>Metadata</h3>
             <pre>{
-        "path": "test.csv"
+        "file": "test.csv"
       }</pre>
           </section>
       

--- a/tests/testthat/_snaps/pin-upload-download.md
+++ b/tests/testthat/_snaps/pin-upload-download.md
@@ -3,11 +3,11 @@
     Code
       pin_upload(board, 1:10)
     Error <rlang_error>
-      `path` must be a string
+      `path` must be a character vector
     Code
       pin_upload(board, "this-path-doesn't-exist")
     Error <rlang_error>
-      `path` must exist
+      All elements of `path` must exist
     Code
       path <- fs::file_touch(fs::path_temp("test.txt"))
       pin_upload(board, path)

--- a/tests/testthat/test-board_local.R
+++ b/tests/testthat/test-board_local.R
@@ -80,6 +80,20 @@ test_that("can pin_read() pins made by pin()", {
   # pin.default
 })
 
+test_that("can upload/download multiple files", {
+  path1 <- withr::local_tempfile()
+  writeLines("a", path1)
+  path2 <- withr::local_tempfile()
+  writeLines("b", path2)
+
+  board <- board_temp()
+  suppressMessages(pin_upload(board, c(path1, path2), "test"))
+
+  out <- pin_download(board, "test")
+  expect_equal(length(out), 2)
+  expect_equal(readLines(out[[1]]), "a")
+  expect_equal(readLines(out[[2]]), "b")
+})
 
 test_that("can't unversion an unversioned pin", {
   expect_snapshot(error = TRUE, {

--- a/tests/testthat/test-board_rsconnect.R
+++ b/tests/testthat/test-board_rsconnect.R
@@ -36,6 +36,23 @@ test_that("can search pins", {
   expect_equal(nrow(board_pin_find(board, "xyzxyzxyzxyz")), 1)
 })
 
+test_that("can upload/download multiple files", {
+  path1 <- withr::local_tempfile()
+  writeLines("a", path1)
+  path2 <- withr::local_tempfile()
+  writeLines("b", path2)
+
+  board <- board_rsconnect_test()
+  suppressMessages(pin_upload(board, c(path1, path2), "test-multi-file"))
+  withr::defer(board_pin_remove(board, "test-multi-file"))
+
+  out <- pin_download(board, "test")
+  expect_equal(length(out), 2)
+  expect_equal(readLines(out[[1]]), "a")
+  expect_equal(readLines(out[[2]]), "b")
+})
+
+
 # versioning --------------------------------------------------------------
 
 test_that("versioned by default", {

--- a/tests/testthat/test-board_rsconnect_bundle.R
+++ b/tests/testthat/test-board_rsconnect_bundle.R
@@ -5,7 +5,7 @@ test_that("bundle contains expected files", {
   saveRDS(df, fs::path(path, "test.rds"))
 
   board <- list(account = "TEST", server = "example.com")
-  metadata <- list(path = "test.rds")
+  metadata <- list(file = "test.rds")
 
   out <- rsc_bundle(board, "test", fs::path(path, "test.rds"), list(), df)
 
@@ -21,7 +21,7 @@ test_that("generates index files", {
   expect_snapshot({
     board <- list(account = "TEST", server = "example.com")
     df <- data.frame(x = 1:2, y = 2:1)
-    metadata <- list(path = "test.csv")
+    metadata <- list(file = "test.csv")
 
     cat(rsc_bundle_preview_index(board, "test", df, metadata))
   })


### PR DESCRIPTION
Including discovery that `board_rsconnect()` was inconsistently using `path` metadata key instead of `file`.

Fixes #427