### PR TITLE
remove the 1.7.7 version constraint

### DIFF
--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -106,10 +106,6 @@ board_rsconnect <- function(
   # Fill in account name if auth == "envvar"
   board$account <- board$account %||% rsc_GET(board, "users/current/")$username
 
-  if (rsc_version(board) < "1.7.7") {
-    abort("Pins requires RSC 1.7.7 or later")
-  }
-
   board
 }
 


### PR DESCRIPTION
partial solution to #467

Avoids problems parsing some (development) RSC version strings or (by configuration) unavailable versions.

This does not resolve API compatibility with old RSC releases.