### PR TITLE
Fix the URL on servers that have hostname + path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     openssl,
     rappdirs,
     rlang,
+    rsconnect,
     tibble,
     whisker,
     withr,
@@ -52,7 +53,6 @@ Suggests:
     paws.storage,
     R.utils,
     rmarkdown,
-    rsconnect,
     shiny,
     testthat (>= 3.0.0),
     xml2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Imports:
     openssl,
     rappdirs,
     rlang,
-    rsconnect,
     tibble,
     whisker,
     withr,
@@ -53,6 +52,7 @@ Suggests:
     paws.storage,
     R.utils,
     rmarkdown,
+    rsconnect,
     shiny,
     testthat (>= 3.0.0),
     xml2

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -71,7 +71,8 @@ board_rsconnect <- function(
     server <- server %||% envvar_get("CONNECT_SERVER") %||% abort("`server` must be supplied")
     server_name <- httr::parse_url(server)$hostname
     # account determined below
-    url <- paste0(server, "/__api__/")
+    url <- paste0(server, "/__api__/") # remember to delete this line
+    url <- rsconnect::serverInfo(name = server)$url
 
     key <- key %||% envvar_get("CONNECT_API_KEY") %||% abort("`key` must be supplied")
     account_info <- NULL

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -597,6 +597,7 @@ rsc_path <- function(board, path) {
 
 
 rsc_ensure_path_url <- function(board, url) {
+  if (length(url) == 0) return(url)
   server_name <- dirname(board$server_name)
   full_name <- board$server_name
   if (!grepl(full_name, url)) {

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -600,7 +600,7 @@ rsc_ensure_path_url <- function(board, url) {
   if (length(url) == 0) return(url)
   server_name <- dirname(board$server_name)
   full_name <- board$server_name
-  if (!grepl(full_name, url)) {
+  if (!grepl(full_name, url, fixed = TRUE)) {
     url <- sub(server_name, full_name, url)
   }
   url

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -592,7 +592,7 @@ update_cache <- function(path, key, value) {
 
 rsc_path <- function(board, path) {
   board_path <- httr::parse_url(board$url)$path
-  paste0("/", board_path, "/", path)
+  file.path(board_path, path, fsep = "/")
 }
 
 
@@ -618,7 +618,7 @@ rsc_GET <- function(board, path, query = NULL, ...) {
   )
   rsc_check_status(req)
   content <- httr::content(req)
-  if (is.list(content[[1]])) {
+  if (length(content) && is.list(content) && is.list(content[[1]])) {
     # ensure the full server name is in the URL
     content[[1]][["content_url"]] <- rsc_ensure_path_url(board, content[[1]][["content_url"]])
   }


### PR DESCRIPTION
This attempts to fix #469, although some more work might be required, since the tests don't all pass locally.

The root cause is that the function `board_rsconnect()` constructs the server URL from `hostname` + `__api__`.  However, this ignores the fact that the full domain name can contain `hostname` + `path` + `__api__`.

For example, if the real server is at `colorado.rstudio.com/rsc`, then the API endpoint is at `colorado.rstudio.com/rsc/__api__`, but the current code base ignores the `/rsc` path.

One solution to this is to use `rsconnect::serverInfo()` to construct the URL, like this:

```r
url <- rsconnect::serverInfo(name = server)$url
```

instead of the current:

```r
url <- paste0(server, "/__api__/") # remember to delete this line
```

Here is a reprex:

```
board <- board_rsconnect(server = "https://colorado.rstudio.com/rsc")
pin_read(board, "andrie/mtcars-test")
```