### PR TITLE
Mark cached pins as read only

### DIFF
--- a/R/board_azure.R
+++ b/R/board_azure.R
@@ -181,6 +181,7 @@ azure_download <- function(board, keys, progress = !is_testing()) {
       board$container, keys[needed], paths[needed],
       max_concurrent_transfers = board$n_processes
     )
+    fs::file_chmod(paths[needed], "u=r")
   }
 
   invisible()

--- a/R/board_folder.R
+++ b/R/board_folder.R
@@ -85,7 +85,8 @@ pin_store.pins_board_folder <- function(board, name, paths, metadata,
   version_dir <- fs::path(board$path, name, version)
   fs::dir_create(version_dir)
   write_meta(metadata, version_dir)
-  fs::file_copy(paths, version_dir, overwrite = TRUE)
+  out_paths <- fs::file_copy(paths, version_dir, overwrite = TRUE)
+  fs::file_chmod(out_paths, "u=r")
 
   name
 }

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -562,6 +562,7 @@ rsc_download <- function(board, content_url, dest_path, name) {
 
   rsc_check_status(req)
   fs::file_copy(temp, dest) # only copy if request is successful
+  fs::file_chmod(dest, "u=r")
   invisible()
 }
 

--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -234,6 +234,7 @@ s3_download <- function(board, key, immutable = FALSE) {
   if (!immutable || !fs::file_exists(path)) {
     resp <- board$svc$get_object(Bucket = board$bucket, Key = key)
     writeBin(resp$Body, path)
+    fs::file_chmod(path, "u=r")
   }
 
   path

--- a/R/board_url.R
+++ b/R/board_url.R
@@ -192,6 +192,7 @@ http_download <- function(url, path_dir, path_file, use_cache_on_failure = FALSE
   } else if (httr::status_code(req) <= 200) {
     signal("", "pins_cache_downloaded")
     fs::file_copy(tmp_path, path, overwrite = TRUE)
+    fs::file_chmod(path, "u=r")
 
     info <- httr::cache_info(req)
     if (info$cacheable) {

--- a/R/cache.R
+++ b/R/cache.R
@@ -90,7 +90,9 @@ dir_size <- function(x) {
 cache_touch <- function(board, meta) {
   path <- fs::path(meta$local$dir, "data.txt")
   if (fs::file_exists(path)) {
+    fs::file_chmod(path, "u+w")
     fs::file_touch(path)
+    fs::file_chmod(path, "u=r")
   } else {
     fs::file_create(path)
   }

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -82,6 +82,8 @@ pin_write <- function(board, x,
 
   filename <- fs::path_ext_set(fs::path_file(name), type)
   path <- object_write(x, fs::path_temp(filename), type = type)
+  withr::defer(fs::file_delete(path))
+
   meta <- standard_meta(path, object = x, type = type, desc = desc)
   meta$user <- metadata
 

--- a/R/pin-upload-download.R
+++ b/R/pin-upload-download.R
@@ -1,7 +1,9 @@
 #' Upload and download files to and from a board
 #'
 #' This is a lower-level interface than `pin_read()` and `pin_write()` that
-#' you can use to pin any file.
+#' you can use to pin any file, as opposed to any R object. The path returned
+#' by `pin_download()` is a read-only path to a cached file: you should never
+#' attempt to modify this file.
 #'
 #' @inheritParams pin_read
 #' @return `pin_download()` returns a character vector of file paths;

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -58,6 +58,12 @@ test_api_basic <- function(board) {
     testthat::expect_equal(readLines(out[[2]]), "b")
   })
 
+  testthat::test_that("cached data is read-only", {
+    name <- local_pin(board, 1)
+    path <- pin_download(board, name)
+    testthat::expect_false(fs::file_access(path, "write"))
+  })
+
   testthat::test_that("can round-trip pin data", {
     name <- local_pin(board, 1)
     testthat::expect_equal(pin_read(board, name), 1)

--- a/man/pin_download.Rd
+++ b/man/pin_download.Rd
@@ -40,7 +40,9 @@ avoid potential clashes with the metadata that pins itself uses.}
 }
 \description{
 This is a lower-level interface than \code{pin_read()} and \code{pin_write()} that
-you can use to pin any file.
+you can use to pin any file, as opposed to any R object. The path returned
+by \code{pin_download()} is a read-only path to a cached file: you should never
+attempt to modify this file.
 }
 \examples{
 board <- board_temp()

--- a/tests/testthat/test-board_url.R
+++ b/tests/testthat/test-board_url.R
@@ -125,3 +125,10 @@ test_that("no request if cache-control set", {
     class = "pins_cache_cached"
   )
 })
+
+test_that("http_download saves read-only file", {
+  skip_on_cran()
+  path <- fs::dir_create(withr::local_tempdir())
+  cached <- http_download("https://httpbin.org/cache", path, "test")
+  expect_false(fs::file_access(cached, "write"))
+})


### PR DESCRIPTION
Ensuring that the user can't accidentally modify. Fixes #475