### PR TITLE
Allow board_rsconnect() to work offline

### DIFF
--- a/R/board_url.R
+++ b/R/board_url.R
@@ -15,8 +15,8 @@
 #'   `board_url` will look for a `data.txt` that provides metadata. The
 #'   easiest way to generate this file is to upload a pin directory created by
 #'   [board_folder()].
-#' @param use_cache_on_failure If the url fails to download, is it ok to
-#'   use the last cached failure? Defaults to `is_interactive()` so you'll
+#' @param use_cache_on_failure If the pin fails to download, is it ok to
+#'   use the last cached version? Defaults to `is_interactive()` so you'll
 #'   be robust to poor internet connectivity when exploring interactively,
 #'   but you'll get clear errors when the code is deployed.
 #' @family boards

--- a/man/board_rsconnect.Rd
+++ b/man/board_rsconnect.Rd
@@ -13,6 +13,7 @@ board_rsconnect(
   cache = NULL,
   name = "rsconnect",
   versioned = TRUE,
+  use_cache_on_failure = is_interactive(),
   versions = deprecated()
 )
 }
@@ -42,6 +43,11 @@ generally needed since you should be passing around an explicit
 board object.}
 
 \item{versioned}{Should this board be registered with support for versions?}
+
+\item{use_cache_on_failure}{If the pin fails to download, is it ok to
+use the last cached version? Defaults to \code{is_interactive()} so you'll
+be robust to poor internet connectivity when exploring interactively,
+but you'll get clear errors when the code is deployed.}
 
 \item{versions}{Should this board be registered with support for versions?}
 }

--- a/man/board_url.Rd
+++ b/man/board_url.Rd
@@ -16,8 +16,8 @@ easiest way to generate this file is to upload a pin directory created by
 downloading files multiple times. The default stores in a standard
 cache location for your operating system, but you can override if needed.}
 
-\item{use_cache_on_failure}{If the url fails to download, is it ok to
-use the last cached failure? Defaults to \code{is_interactive()} so you'll
+\item{use_cache_on_failure}{If the pin fails to download, is it ok to
+use the last cached version? Defaults to \code{is_interactive()} so you'll
 be robust to poor internet connectivity when exploring interactively,
 but you'll get clear errors when the code is deployed.}
 }

--- a/tests/testthat/test-board_rsconnect.R
+++ b/tests/testthat/test-board_rsconnect.R
@@ -84,3 +84,17 @@ test_that("can parse user & pin name", {
   expect_equal(rsc_parse_name("x"), list(owner = NULL, name = "x", full = NULL))
   expect_equal(rsc_parse_name("y/x"), list(owner = "y", name = "x", full = "y/x"))
 })
+
+test_that("can find cached versions", {
+  board <- board_rsconnect_test()
+  name <- local_pin(board, 1)
+  pin_read(board, name)
+
+  guid <- rsc_content_find(board, name)$guid
+  expect_message(cached_v <- rsc_content_version_cached(board, guid), "cached")
+  expect_equal(cached_v, rsc_content_version_live(board, guid))
+
+  pin_write(board, 2, name)
+  # Cached version hasn't changed since we haven't read
+  expect_message(expect_equal(rsc_content_version_cached(board, guid), cached_v))
+})


### PR DESCRIPTION
I don't see how to test this automatically, but I tested it manually by turning off my wifi and checking that I could connect to a board and download a previously retrieved pin.

Fixes #423