### PR TITLE
Clarify board_rsconnect allows manual authentication

### DIFF
--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -35,9 +35,11 @@
 #'
 #' @inheritParams new_board
 #' @inheritParams board_url
-#' @param auth There are three approaches to auth: use `"manual"` and provide `server` and `key`,
-#'   use `"envvars"`  `CONNECT_API_KEY` and `CONNECT_SERVER`, or the rsconnect package. The
-#'   default is `auto`, which will use the manually provided values if present, then
+#' @param auth There are three approaches to auth:
+#'  * Use `"manual"` along with arguments `server` and `key`.
+#'  * Use `"envvars"` with environment variables `CONNECT_API_KEY` and `CONNECT_SERVER`.
+#'  * Use the `"rsconnect"` package.
+#'  * The default is `auto`, which will use the manually provided values if present, then
 #'   environment variables if both are available, and rsconnect if not.
 #' @param server For `auth = "manual"` or `auth = 'envvar'`, the full url to the server,
 #'   like `http://server.rstudio.com/rsc` or `https://connect.rstudio.com/`.

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -35,12 +35,12 @@
 #'
 #' @inheritParams new_board
 #' @inheritParams board_url
-#' @param auth There are two approaches to auth: you can either use `"envvars"`
-#'   `CONNECT_API_KEY` and `CONNECT_SERVER` or the rsconnect package. The
-#'   default is `auto`, which will use the environment variables if both are
-#'   available, and rsconnect if not.
-#' @param server For `auth = "envvar"` the full url to the server, like
-#'   `http://server.rstudio.com/rsc` or `https://connect.rstudio.com/`.
+#' @param auth There are three approaches to auth: you can manually provide `server` and `key`,
+#'   use `"envvars"`  `CONNECT_API_KEY` and `CONNECT_SERVER`, or the rsconnect package. The
+#'   default is `auto`, which will use the manually provided values if present, then 
+#'   environment variables if both are available, and rsconnect if not.
+#' @param server For `auth = "envvar"` or a directly provided value, the full url to the server,
+#'   like `http://server.rstudio.com/rsc` or `https://connect.rstudio.com/`.
 #'   For `auth = 'rsconnect'` a host name used to disambiguate RSC accounts,
 #'   like `server.rstudio.com` or `connect.rstudio.com`.
 #' @param account A user name used to disambiguate multiple RSC accounts

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -35,15 +35,15 @@
 #'
 #' @inheritParams new_board
 #' @inheritParams board_url
-#' @param auth There are three approaches to auth: you can manually provide `server` and `key`,
+#' @param auth There are three approaches to auth: use `"manual"` and provide `server` and `key`,
 #'   use `"envvars"`  `CONNECT_API_KEY` and `CONNECT_SERVER`, or the rsconnect package. The
-#'   default is `auto`, which will use the manually provided values if present, then 
+#'   default is `auto`, which will use the manually provided values if present, then
 #'   environment variables if both are available, and rsconnect if not.
-#' @param server For `auth = "envvar"` or a directly provided value, the full url to the server,
+#' @param server For `auth = "manual"` or `auth = 'envvar'`, the full url to the server,
 #'   like `http://server.rstudio.com/rsc` or `https://connect.rstudio.com/`.
 #'   For `auth = 'rsconnect'` a host name used to disambiguate RSC accounts,
 #'   like `server.rstudio.com` or `connect.rstudio.com`.
-#' @param account A user name used to disambiguate multiple RSC accounts
+#' @param account A user name used to disambiguate multiple RSC accounts.
 #' @param key The RStudio Connect API key.
 #' @param output_files `r lifecycle::badge("deprecated") No longer supported.
 #' @family boards

--- a/R/board_rsconnect_server.R
+++ b/R/board_rsconnect_server.R
@@ -1,23 +1,26 @@
 rsc_server <- function(auth = "auto", server = NULL, account = NULL, key = NULL) {
-  auth <- check_auth(auth)
+  auth <- check_auth(auth, server, key)
 
-  if (auth == "envvar") {
+  if (auth %in%  c("manual", "envvar")) {
     rsc_server_envvar(server, key)
   } else {
     rsc_server_rsconnect(server, account)
   }
 }
 
-check_auth <- function(auth = c("auto", "envvar", "rsconnect")) {
+check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server, key) {
   auth <- arg_match(auth)
   if (auth == "auto") {
-    if (has_envvars(c("CONNECT_API_KEY", "CONNECT_SERVER"))) {
+    if (!is.null(server) && !is.null(key)) {
+      "manual"
+    } else if (has_envvars(c("CONNECT_API_KEY", "CONNECT_SERVER"))) {
       "envvar"
     } else if (rsc_rsconnect_is_configured()) {
       "rsconnect"
     } else {
       abort(c(
         "auth = `auto` has failed to find a way to authenticate",
+        "`server` and `key` not provided for `auth= 'manual'`",
         "Can't find CONNECT_SERVER and CONNECT_API_KEY envvars for `auth = 'envvar'`",
         "Can't find any rsconnect::accounts() for `auth = 'rsconnect'`"
       ))

--- a/R/board_rsconnect_server.R
+++ b/R/board_rsconnect_server.R
@@ -22,7 +22,7 @@ check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server
     } else {
       abort(c(
         "auth = `auto` has failed to find a way to authenticate",
-        "`server` and `key` not provided for `auth= 'manual'`",
+        "`server` and `key` not provided for `auth = 'manual'`",
         "Can't find CONNECT_SERVER and CONNECT_API_KEY envvars for `auth = 'envvar'`",
         "Can't find any rsconnect::accounts() for `auth = 'rsconnect'`"
       ))

--- a/R/board_rsconnect_server.R
+++ b/R/board_rsconnect_server.R
@@ -34,7 +34,7 @@ check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server
 
 rsc_server_manual <- function(server, key) {
   url <- server %||% abort("`server` must be supplied")
-  url <- rsc_normalize_server_url(server)
+  url <- rsc_normalize_server_url(url)
   server_name <- httr::parse_url(url)$hostname
 
   key <- key %||% abort("`key` must be supplied")

--- a/R/board_rsconnect_server.R
+++ b/R/board_rsconnect_server.R
@@ -1,14 +1,16 @@
 rsc_server <- function(auth = "auto", server = NULL, account = NULL, key = NULL) {
   auth <- check_auth(auth, server, key)
 
-  if (auth %in%  c("manual", "envvar")) {
-    rsc_server_envvar(server, key)
+  if (auth == "manual") {
+    rsc_server_manual(server, key)
+  } else if (auth == "envvar") {
+    rsc_server_manual(envvar_get("CONNECT_SERVER"), envvar_get("CONNECT_API_KEY"))
   } else {
     rsc_server_rsconnect(server, account)
   }
 }
 
-check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server, key) {
+check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server = NULL, key = NULL) {
   auth <- arg_match(auth)
   if (auth == "auto") {
     if (!is.null(server) && !is.null(key)) {
@@ -30,12 +32,12 @@ check_auth <- function(auth = c("auto", "manual", "envvar", "rsconnect"), server
   }
 }
 
-rsc_server_envvar <- function(server = NULL, key = NULL) {
-  url <- server %||% envvar_get("CONNECT_SERVER") %||% abort("`server` must be supplied")
-  url <- rsc_normalize_server_url(url)
+rsc_server_manual <- function(server, key) {
+  url <- server %||% abort("`server` must be supplied")
+  url <- rsc_normalize_server_url(server)
   server_name <- httr::parse_url(url)$hostname
 
-  key <- key %||% envvar_get("CONNECT_API_KEY") %||% abort("`key` must be supplied")
+  key <- key %||% abort("`key` must be supplied")
 
   list(
     url = url,

--- a/tests/testthat/_snaps/board_rsconnect_server.md
+++ b/tests/testthat/_snaps/board_rsconnect_server.md
@@ -4,7 +4,7 @@
       check_auth()
     Error <rlang_error>
       auth = `auto` has failed to find a way to authenticate
-      * `server` and `key` not provided for `auth= 'manual'`
+      * `server` and `key` not provided for `auth = 'manual'`
       * Can't find CONNECT_SERVER and CONNECT_API_KEY envvars for `auth = 'envvar'`
       * Can't find any rsconnect::accounts() for `auth = 'rsconnect'`
 

--- a/tests/testthat/_snaps/board_rsconnect_server.md
+++ b/tests/testthat/_snaps/board_rsconnect_server.md
@@ -4,6 +4,7 @@
       check_auth()
     Error <rlang_error>
       auth = `auto` has failed to find a way to authenticate
+      * `server` and `key` not provided for `auth= 'manual'`
       * Can't find CONNECT_SERVER and CONNECT_API_KEY envvars for `auth = 'envvar'`
       * Can't find any rsconnect::accounts() for `auth = 'rsconnect'`
 
@@ -25,7 +26,7 @@
 # auth is hidden
 
     Code
-      server <- rsc_server_envvar("http://example.com", "SECRET")
+      server <- rsc_server_manual("http://example.com", "SECRET")
       server$auth
     Output
       <hidden>

--- a/tests/testthat/test-board_rsconnect_server.R
+++ b/tests/testthat/test-board_rsconnect_server.R
@@ -38,15 +38,15 @@ test_that("delivers useful messages if can't find RSC account", {
 
 test_that("server url is normalised", {
   ref <- "http://example.com/test"
-  expect_equal(rsc_server_envvar("http://example.com/test", "")$url, ref)
-  expect_equal(rsc_server_envvar("http://example.com/test/", "")$url, ref)
-  expect_equal(rsc_server_envvar("http://example.com/test/__api__", "")$url, ref)
-  expect_equal(rsc_server_envvar("http://example.com/test/__api__/", "")$url, ref)
+  expect_equal(rsc_server_manual("http://example.com/test", "")$url, ref)
+  expect_equal(rsc_server_manual("http://example.com/test/", "")$url, ref)
+  expect_equal(rsc_server_manual("http://example.com/test/__api__", "")$url, ref)
+  expect_equal(rsc_server_manual("http://example.com/test/__api__/", "")$url, ref)
 })
 
 test_that("auth is hidden", {
   expect_snapshot({
-    server <- rsc_server_envvar("http://example.com", "SECRET")
+    server <- rsc_server_manual("http://example.com", "SECRET")
     server$auth
     str(list(1, server$auth, 2))
   })

--- a/tests/testthat/test-board_rsconnect_server.R
+++ b/tests/testthat/test-board_rsconnect_server.R
@@ -1,9 +1,12 @@
-test_that("auth allows envvar and rsconnect values", {
+test_that("auth allows manual, envvar and rsconnect values", {
+  expect_equal(check_auth("manual"), "manual")
   expect_equal(check_auth("envvar"), "envvar")
   expect_equal(check_auth("rsconnect"), "rsconnect")
 })
 
 test_that("auth='auto' picks appropriate method and error if none found", {
+  expect_equal(check_auth(server = "", key = ""), "manual")
+
   withr::local_envvar("CONNECT_API_KEY" = "", "CONNECT_SERVER" = "")
   mockery::stub(check_auth, "rsc_rsconnect_is_configured", TRUE)
   expect_equal(check_auth(), "rsconnect")


### PR DESCRIPTION
Mention manual authorization in `board_rsconnect()`. I don't know if it makes sense to change the function to accept a separate manual option or not. If you think so, I can add something like that. 

Closes #508 