### PR TITLE
Add qs format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     knitr,
     mockery,
     paws.storage,
+    qs,
     R.utils,
     rmarkdown,
     rsconnect,

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -46,7 +46,7 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   When retrieving the pin, this will be stored in the `user` key, to
 #'   avoid potential clashes with the metadata that pins itself uses.
 #' @param type File type used to save `x` to disk. Must be one of
-#'   "csv", "rds", "json", or "arrow". If not supplied will use json for bare
+#'   "csv", "rds", "json", "arrow", or "qs". If not supplied will use json for bare
 #'   lists and rds for everything else.
 #' @param versioned Should the pin be versioned? The default, `NULL`, will
 #'   use the default for `board`
@@ -111,7 +111,7 @@ guess_type <- function(x) {
 }
 
 object_write <- function(x, path, type = "rds") {
-  type <- arg_match0(type, c("rds", "json", "arrow", "pickle", "csv", "qs"))
+  type <- arg_match0(type, setdiff(object_types, "file"))
 
   switch(type,
     rds = write_rds(x, path),

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -37,7 +37,7 @@ you expect. You can find the hash of an existing pin by looking for
 \item{x}{An object (typically a data frame) to pin.}
 
 \item{type}{File type used to save \code{x} to disk. Must be one of
-"csv", "rds", "json", or "arrow". If not supplied will use json for bare
+"csv", "rds", "json", "arrow", or "qs". If not supplied will use json for bare
 lists and rds for everything else.}
 
 \item{title}{A title for the pin; most important for shared boards so that

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -19,7 +19,7 @@
     Code
       pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     Error <rlang_error>
-      `type` must be one of "rds", "json", "arrow", "pickle", or "csv".
+      `type` must be one of "rds", "json", "arrow", "pickle", "csv", or "qs".
     Code
       pin_write(board, mtcars, name = "mtcars", metadata = 1)
     Error <rlang_error>

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -12,6 +12,9 @@ test_that("can round trip all types", {
   pin_write(board, df, "df-3", type = "csv")
   expect_equal(pin_read(board, "df-3"), df)
 
+  pin_write(board, df, "df-4", type = "qs")
+  expect_equal(pin_read(board, "df-4"), df)
+
   # List
   x <- list(a = 1:5, b = 1:10)
   pin_write(board, x, "x-1", type = "json")

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -65,6 +65,7 @@ But you can choose another option depending on your goals:
 -   `type = "csv"` uses `write.csv()` to create a `.csv` file. CSVs can read by any application, but only support simple columns (e.g. numbers, strings, dates), can take up a lot of disk space, and can be slow to read.
 -   `type = "arrow"` uses `arrow::write_feather()` to create an arrow/feather file. [Arrow](https://arrow.apache.org) is a modern, language-independent, high-performance file format designed for data science. Not every tool can read arrow files, but support is growing rapidly.
 -   `type = "json"` uses `jsonlite::write_json()` to create a `.json` file. Pretty much every programming language can read json files, but they only work well for nested lists.
+-   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/traversc/qs).
 
 After you've pinned an object, you can read it back with `pin_read()`:
 


### PR DESCRIPTION
There are arguments in both [`qsave()`](https://rdrr.io/cran/qs/man/qsave.html) and [`qread()`](https://rdrr.io/cran/qs/man/qread.html) which can affect the performance of reading and writing. Regardless, [qs performs better than RDS](https://github.com/traversc/qs), so I don't think providing a mechanism to change the defaults is needed, at least not initially.