### PR TITLE
disable rsc workflow if the license is empty

### DIFF
--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,6 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
+    if: ${{ secrets.RSC_LICENSE != "" }}
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: github.repository == "rstudio/pins"
+    if: github.repository == 'rstudio/pins'
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == "github.com/rstudio/pins" }}
+    if: github.repository == "rstudio/pins"
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: secrets.RSC_LICENSE != ''
+    if: github.repository == 'rstudio/pins'
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: ${{ secrets.RSC_LICENSE != "" }}
+    if: ${{ github.repository == "github.com/rstudio/pins" }}
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: github.repository == 'rstudio/pins'
+    if: secrets.RSC_LICENSE != ''
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}

--- a/.github/workflows/rstudio-connect.yaml
+++ b/.github/workflows/rstudio-connect.yaml
@@ -9,7 +9,7 @@ name: rstudio-connect
 jobs:
   rstudio-connect:
     runs-on: ubuntu-latest
-    if: github.repository == 'rstudio/pins'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
     env:
       RSC_VERSION: 1.8.6.2
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}


### PR DESCRIPTION
Having a hard time determining that "this PR is coming from a fork"

- `github.repository` is always set to `rstudio/pins`
- `secrets` is not available in the `if` block