### PR TITLE
Update RSC test boards

### DIFF
--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -699,7 +699,7 @@ board_rsconnect_hadley <- function(...) {
 
 board_rsconnect_susan <- function(...) {
   creds <- read_creds()
-  board_rsconnect("envvar",
+  board_rsconnect(
     server = "http://localhost:3939",
     account = "susan",
     key = creds$susan_key
@@ -707,7 +707,7 @@ board_rsconnect_susan <- function(...) {
 }
 board_rsconnect_derek <- function(...) {
   creds <- read_creds()
-  board_rsconnect("envvar",
+  board_rsconnect(
     server = "http://localhost:3939",
     account = "derek",
     key = creds$derek_key

--- a/R/board_rsconnect_server.R
+++ b/R/board_rsconnect_server.R
@@ -4,7 +4,10 @@ rsc_server <- function(auth, server = NULL, account = NULL, key = NULL) {
   if (auth == "manual") {
     rsc_server_manual(server, key)
   } else if (auth == "envvar") {
-    rsc_server_manual(envvar_get("CONNECT_SERVER"), envvar_get("CONNECT_API_KEY"))
+    rsc_server_manual(
+      envvar_get("CONNECT_SERVER") %||% abort("Can't find CONNECT_SERVER env var"),
+      envvar_get("CONNECT_API_KEY") %||% abort("Can't find CONNECT_API_KEY env var")
+    )
   } else {
     rsc_server_rsconnect(server, account)
   }

--- a/tests/testthat/_snaps/board_rsconnect_server.md
+++ b/tests/testthat/_snaps/board_rsconnect_server.md
@@ -38,3 +38,17 @@
        $ : <hidden>
        $ : num 2
 
+# clearly errors if env vars missing
+
+    Code
+      rsc_server("envvar")
+    Error <rlang_error>
+      Can't find CONNECT_SERVER env var
+
+---
+
+    Code
+      rsc_server("envvar")
+    Error <rlang_error>
+      Can't find CONNECT_API_KEY env var
+

--- a/tests/testthat/test-board_rsconnect_server.R
+++ b/tests/testthat/test-board_rsconnect_server.R
@@ -51,3 +51,11 @@ test_that("auth is hidden", {
     str(list(1, server$auth, 2))
   })
 })
+
+test_that("clearly errors if env vars missing", {
+  withr::local_envvar("CONNECT_API_KEY" = NA, "CONNECT_SERVER" = NA)
+  expect_snapshot(rsc_server("envvar"), error = TRUE)
+  withr::local_envvar("CONNECT_API_KEY" = NA, "CONNECT_SERVER" = 1)
+  expect_snapshot(rsc_server("envvar"), error = TRUE)
+})
+


### PR DESCRIPTION
Since they never actually used envvars, and this now (correctly) fails. And improve auth="envvar" option to give better errors