### PR TITLE
Updates Connect preview page with improved metadata formatting

### DIFF
--- a/R/board_rsconnect_bundle.R
+++ b/R/board_rsconnect_bundle.R
@@ -59,7 +59,11 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
     data_preview = jsonlite::toJSON(data_preview, auto_unbox = TRUE),
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
     pin_name = paste0(board$account, "/", name),
-    pin_metadata = jsonlite::toJSON(metadata, auto_unbox = TRUE, pretty = TRUE),
+    pin_metadata = yaml::as.yaml(metadata),
+    pin_metadata_date = parse_8601_compact(metadata$created),
+    pin_metadata_format = metadata$type,
+    pin_metadata_api_version = metadata$api_version,
+    pin_metadata_description = metadata$description,
     board_deparse = paste0(expr_deparse(board_deparse(board)), collapse = "\n")
   )
 

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -25,6 +25,22 @@
     </style>
   </head>
   <body>
+
+    <section>
+      <h3>{{{pin_name}}}</h3>
+      <p>
+        Last updated: {{{pin_metadata_date}}} •
+        Format: {{{pin_metadata_format}}} •
+        API: v{{{pin_metadata_api_version}}}
+      </p>
+      <p>{{{pin_metadata_description}}}</p>
+      <p>Download data: {{{pin_files}}}</p>
+      <details>
+        <summary>Raw metadata</summary>
+        <pre>{{{pin_metadata}}}</pre>
+      </details>
+    </section>
+
     <section>
     <h3>Code</h3>
       <pre id="pin-r" class="pin-code"><code class="r">library(pins)
@@ -34,18 +50,6 @@ pin_read(board, "{{pin_name}}")</code></pre>
       hljs.registerLanguage("r", highlight_r);
       hljs.initHighlightingOnLoad();
     </script>
-    </section>
-
-    <section>
-      <h3>Raw data</h3>
-      <div class="pin-download">
-        {{{pin_files}}}
-      </div>
-    </section>
-
-    <section>
-      <h3>Metadata</h3>
-      <pre>{{{pin_metadata}}}</pre>
     </section>
 
     <section style="{{data_preview_style}}">

--- a/tests/testthat/_snaps/board_rsconnect_bundle.md
+++ b/tests/testthat/_snaps/board_rsconnect_bundle.md
@@ -34,6 +34,23 @@
           </style>
         </head>
         <body>
+      
+          <section>
+            <h3>TEST/test</h3>
+            <p>
+              Last updated:  •
+              Format:  •
+              API: v
+            </p>
+            <p></p>
+            <p>Download data: <a href="test.csv">test.csv</a></p>
+            <details>
+              <summary>Raw metadata</summary>
+              <pre>file: test.csv
+      </pre>
+            </details>
+          </section>
+      
           <section>
           <h3>Code</h3>
             <pre id="pin-r" class="pin-code"><code class="r">library(pins)
@@ -43,20 +60,6 @@
             hljs.registerLanguage("r", highlight_r);
             hljs.initHighlightingOnLoad();
           </script>
-          </section>
-      
-          <section>
-            <h3>Raw data</h3>
-            <div class="pin-download">
-              <a href="test.csv">test.csv</a>
-            </div>
-          </section>
-      
-          <section>
-            <h3>Metadata</h3>
-            <pre>{
-        "file": "test.csv"
-      }</pre>
           </section>
       
           <section style="">


### PR DESCRIPTION
Prioritises the display of important metadata like the "created" timestamp and the description.

Raw metadata is now displayed in its original yaml format but hidden from the default view behind a `<details>` tag.

Closes #554
Closes #552 